### PR TITLE
Fixed reversed order of call to annual_mean.compute()

### DIFF
--- a/src/python/pcmdi/mean_climate_metrics_calculations.py
+++ b/src/python/pcmdi/mean_climate_metrics_calculations.py
@@ -29,7 +29,7 @@ def compute_metrics(Var,dm_glb,do_glb):
         cor_xyt = pcmdi_metrics.pcmdi.cor_xyt.compute(dm,do)
         
         ### CALCULATE ANNUAL MEANS
-        do_am, dm_am =  pcmdi_metrics.pcmdi.annual_mean.compute(dm,do)
+        dm_am, do_am =  pcmdi_metrics.pcmdi.annual_mean.compute(dm,do)
         
         ### CALCULATE ANNUAL MEAN BIAS
         bias_xy = pcmdi_metrics.pcmdi.bias.compute(dm_am,do_am)


### PR DESCRIPTION
We found here at GFDL that the statistics for the annual means had the sign reversed.  I tracked this down to a bug in the order of the the returned objects form annual_mean.compute()

Order should be:
   dm_am, do_am =  pcmdi_metrics.pcmdi.annual_mean.compute(dm,do)