### PR TITLE
Issue262 durack1 update CMake release checks and lock UV-CDAT build to 2.2.0

### DIFF
--- a/install_metrics.bash
+++ b/install_metrics.bash
@@ -356,14 +356,14 @@ main() {
     cmake_repo_http=http://cmake.org/cmake.git
     cmake_repo_https=https://cmake.org/cmake.git
     cmake_min_version=2.8.11
-    cmake_max_version=2.9
-    cmake_version=2.8.12
+    cmake_max_version=3.2.3
+    cmake_version=3.2.3
     force_install=0
     DEBUG=1
     cdat_repo=git://github.com/UV-CDAT/uvcdat.git
     cdat_repo_http=http://github.com/UV-CDAT/uvcdat.git
     cdat_repo_https=https://github.com/UV-CDAT/uvcdat.git
-    cdat_version="master"
+    cdat_version="2.2.0"
     metrics_repo=git://github.com/PCMDI/pcmdi_metrics.git
     metrics_repo_http=http://github.com/PCMDI/pcmdi_metrics.git
     metrics_repo_https=https://github.com/PCMDI/pcmdi_metrics.git


### PR DESCRIPTION
Fix #262 - Update CMake release checks and lock UV-CDAT build to 2.2.0

@doutriaux1 @gleckler1 please review and approve ASAP