### PR TITLE
Add coverage2

### DIFF
--- a/tests/all_coverage.json
+++ b/tests/all_coverage.json
@@ -1,3 +1,3 @@
 {
-   "include": ["pcmdi_metrics", "cdat_info", "cdms2", "genutil", "vcs", "vtk"]
+   "include": ["pcmdi_metrics", "pcmdi_metrics/pcmdi", "cdat_info", "cdms2", "genutil", "vcs", "vtk"]
 }

--- a/tests/coverage.json
+++ b/tests/coverage.json
@@ -1,3 +1,3 @@
 {
-   "include": ["pcmdi_metrics"]
+   "include": ["pcmdi_metrics", "pcmdi_metrics/pcmdi"]
 }


### PR DESCRIPTION
add pcmdi_metrics/pcmdi in tests/coverage.json and tests/all_coverage.json.
To see the coverage missing lines of pcmdi_metrics, users can go to last linux_pmp_py3 job in circleci like https://circleci.com/gh/PCMDI/pcmdi_metrics/514
click on 'run_pmp_tests', scroll all the way down.
User can also login to coveralls.io site, and add the repo to view the coverage.