### PR TITLE
CMEC compliant mean climate output

### DIFF
--- a/pcmdi_metrics/driver/outputmetrics.py
+++ b/pcmdi_metrics/driver/outputmetrics.py
@@ -173,7 +173,10 @@ class OutputMetrics(object):
         if self.check_save_test_clim(ref):
             self.output_interpolated_model_climatologies(test, test_data)
 
-        self.write_on_exit(self.parameter.cmec)
+        if hasattr(self.parameter, 'cmec'):
+            self.write_on_exit(self.parameter.cmec)
+        else:
+            self.write_on_exit(False)
 
     def set_grid_in_metrics_dictionary(self, test_data):
         ''' Set the grid in metrics_dictionary. '''

--- a/pcmdi_metrics/driver/outputmetrics.py
+++ b/pcmdi_metrics/driver/outputmetrics.py
@@ -173,7 +173,7 @@ class OutputMetrics(object):
         if self.check_save_test_clim(ref):
             self.output_interpolated_model_climatologies(test, test_data)
 
-        self.write_on_exit()
+        self.write_on_exit(self.parameter.cmec)
 
     def set_grid_in_metrics_dictionary(self, test_data):
         ''' Set the grid in metrics_dictionary. '''
@@ -289,7 +289,7 @@ class OutputMetrics(object):
         return not self.parameter.dry_run and hasattr(self.parameter, 'save_test_clims') \
                and self.parameter.save_test_clims is True and ref.obs_or_model == reference_data_set[0]  # noqa
 
-    def write_on_exit(self):
+    def write_on_exit(self, cmec_flag):
         ''' Output the metrics_dictionary as a json and text file. '''
         self.setup_out_file()
         self.metrics_dictionary['METRICS'] = self.metrics_def_dictionary
@@ -302,3 +302,7 @@ class OutputMetrics(object):
                                 indent=4,
                                 separators=(',', ': '),
                                 mode="r+")
+            if cmec_flag:
+                logging.getLogger("pcmdi_metrics").info(
+                    'CMEC conversion: %s' % self.out_file().replace('.json', '_cmec.json'))
+                self.out_file.write_cmec(indent=4, separators=(',', ': '))

--- a/pcmdi_metrics/driver/outputmetrics.py
+++ b/pcmdi_metrics/driver/outputmetrics.py
@@ -302,7 +302,7 @@ class OutputMetrics(object):
                                 indent=4,
                                 separators=(',', ': '),
                                 mode="r+")
-            if cmec_flag:
+            if cmec_flag is True:
                 logging.getLogger("pcmdi_metrics").info(
                     'CMEC conversion: %s' % self.out_file().replace('.json', '_cmec.json'))
                 self.out_file.write_cmec(indent=4, separators=(',', ': '))

--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -127,8 +127,6 @@ def scrap(data, axis=0):
     return new(order=originalOrder)
 
 
-
-
 class CDMSDomainsEncoder(json.JSONEncoder):
     def default(self, o):
         components = o.components()[0].kargs
@@ -265,11 +263,11 @@ class Base(cdp.cdp_io.CDPIO, genutil.StringConstructor):
             for key in json_dict:
                 if key in keylist:
                     new_dict.pop(key)
-                elif isinstance(new_dict[key],dict):
+                elif isinstance(new_dict[key], dict):
                     tmp_dict = recursive_pop(new_dict[key], keylist)
                     new_dict[key] = tmp_dict
             return new_dict
-        cmec_data["RESULTS"] = recursive_pop(data["RESULTS"], ["source"])
+        cmec_data["RESULTS"] = recursive_pop(data["RESULTS"], ["source", "metadata"])
 
         # Delete extra results fields if present (mean climate)
         model_meta = {}
@@ -294,7 +292,7 @@ class Base(cdp.cdp_io.CDPIO, genutil.StringConstructor):
         def recursive_replace(json_dict, key1, key2):
             new_dict = json_dict.copy()
             for key in json_dict:
-                if isinstance(new_dict[key],dict):
+                if isinstance(new_dict[key], dict):
                     tmp_dict = recursive_replace(new_dict[key], key1, key2)
                     new_dict[key] = tmp_dict
                 if key == key1:

--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -300,6 +300,17 @@ class Base(cdp.cdp_io.CDPIO, genutil.StringConstructor):
             return new_dict
         cmec_data = recursive_replace(cmec_data, "", "Unspecified")
 
+        # Convert metrics to float
+        def update_type(json_dict, type1, type2):
+            for key in json_dict:
+                if isinstance(json_dict[key], dict):
+                    tmp_dict = update_type(json_dict[key], type1, type2)
+                    json_dict[key] = tmp_dict
+                elif (isinstance(json_dict[key], type1) and key != "attributes"):
+                    json_dict[key] = type2(json_dict[key])
+            return json_dict
+        cmec_data["RESULTS"] = update_type(cmec_data["RESULTS"], str, float)
+
         # Populate dimensions fields
         def get_dimensions(json_dict, json_structure):
             keylist = {}

--- a/pcmdi_metrics/pcmdi/mean_climate_metrics_driver.py
+++ b/pcmdi_metrics/pcmdi/mean_climate_metrics_driver.py
@@ -408,4 +408,11 @@ def create_mean_climate_parser():
         help='Provide a short description to help identify this run of the PMP mean climate.',
         required=False)
 
+    parser.add_argument(
+        '--cmec',
+        dest='cmec',
+        help='True to save metrics in CMEC format',
+        default=False,
+        required=False)
+
     return parser

--- a/pcmdi_metrics/version.py
+++ b/pcmdi_metrics/version.py
@@ -1,3 +1,3 @@
 __version__ = 'v1.2.1'
-__git_tag_describe__ = 'v1.2.1-394-gcf14b23'
-__git_sha1__ = 'cf14b234f90ef548601ecb6431cca704f80c901f'
+__git_tag_describe__ = 'v1.2.1-402-ge0d97dd'
+__git_sha1__ = 'e0d97dd9d5e596adea0c09b158172592d5cf71b6'


### PR DESCRIPTION
An option is added to output a cmec-compliant metrics json for the mean climate module in addition to the default metrics json.

- Create "cmec" flag in PMP parser, which can be True or False.
- Add write_cmec method to Base class.
- Add call to write_cmec method in outputmetrics.py script, which handles running metrics for mean climate.

Ultimately, the write_cmec function will be able to handle any of the metrics, but for now it is only written to convert the mean climate output to the CMEC format.

**Testing**
This has been tested in the command line using a custom parameter file with `cmec = True`:
```
python setup.py install
mean_climate_driver.py -p cmec_param.py
```
I have also run the PMP test suite after building this version and all tests passed:
`python run_tests.py -H -v 2`

**Output files**
I have attached a zip file with two output jsons (results from running the command line test above):
rlut_2.5x2.5_regrid2_linear_metrics_cmec.json - cmec output file
rlut_2.5x2.5_regrid2_linear_metrics.json - default output file
[meanclimate.zip](https://github.com/PCMDI/pcmdi_metrics/files/5699533/meanclimate.zip)