### PR TITLE
Fix indexing and error catching for climatologies

### DIFF
--- a/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
+++ b/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
@@ -116,10 +116,10 @@ def clim_calc(var, infile, outfile, outdir, outfilename, start, end):
         lst = outfd.split('/')
         s = '/'
         for ll in range(len(lst)):
-            d = s.join(lst[0:ll])
+            d = s.join(lst[0:ll+1])
             try:
                 os.mkdir(d)
-            except IndexError:
+            except OSError:
                 pass
 
         g = cdms2.open(out, 'w+')


### PR DESCRIPTION
When looping through directories, an error would happen where the first directory name was an empty value because line 119 would resolve as d = s.join(lst[0:0]). This throws a FileNotFoundError because '' is not a directory. Also, if a directory already exists, it would throw an OSError which is was not being caught.

Test run:

$ python ../../../pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py \
--var 'rlut' \
--start 2003-01 --end 2018-12 \
--outfile './demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc' \
--infile './demo_data/PCMDIobs2/atmos/mon/rlut/CERES-EBAF-4-1/gn/v20200707/rlut_mon_CERES-EBAF-4-1_BE_gn_v20200707_200301-201812.nc'
start and end are  2003-01   2018-12
var is  rlut
infilename is  rlut_mon_CERES-EBAF-4-1_BE_gn_v20200707_200301-201812.nc
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
outdir is  None
start_yr_str is  2003
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
out is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.AC.v20210126.nc
(12, 180, 360)   (12, 180, 360)   ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.AC.v20210126.nc
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
out is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.DJF.v20210126.nc
(180, 360)   (12, 180, 360)   ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.DJF.v20210126.nc
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
out is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.MAM.v20210126.nc
(180, 360)   (12, 180, 360)   ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.MAM.v20210126.nc
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
out is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.JJA.v20210126.nc
(180, 360)   (12, 180, 360)   ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.JJA.v20210126.nc
outfd is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.nc
out is  ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.SON.v20210126.nc
(180, 360)   (12, 180, 360)   ./demo_output/climo/rlut_mon_CERES-EBAF-4-1_BE_200301-201812.AC.200301-201812.SON.v20210126.nc