### PR TITLE
Add cmec formatted results to MJO and install driver as executable

### DIFF
--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -290,7 +290,9 @@ class Base(cdp.cdp_io.CDPIO, genutil.StringConstructor):
                         "best_matching_model_eofs__rms",
                         "best_matching_model_eofs__tcor_cbf_vs_eof_pc",
                         "period",
-                        "target_model_eofs"]
+                        "target_model_eofs",
+                        "analysis_time_window_end_year",
+                        "analysis_time_window_start_year"]
         # clean up formatting in RESULTS section
         cmec_data["RESULTS"] = recursive_replace(data["RESULTS"], extra_fields)
 
@@ -301,6 +303,7 @@ class Base(cdp.cdp_io.CDPIO, genutil.StringConstructor):
             while level < len(json_structure):
                 if isinstance(json_dict, dict):
                     first_key = list(json_dict.items())[0][0]
+                    # skip over attributes key when building dimensions
                     if first_key == "attributes":
                         first_key = list(json_dict.items())[1][0]
                     dim = json_structure[level]

--- a/pcmdi_metrics/mjo/lib/argparse_functions.py
+++ b/pcmdi_metrics/mjo/lib/argparse_functions.py
@@ -93,6 +93,10 @@ def AddParserArgument(P):
                    type=bool,
                    default=True,
                    help="Option for update existing JSON file: True (i.e., update) (default) / False (i.e., overwrite)")
+    P.add_argument("--cmec",
+                   dest='cmec',
+                   default=False,
+                   help='Option to save metrics in CMEC format: True / False (default)')
     # Parallel
     P.add_argument("--parallel",
                    action="store_true",

--- a/pcmdi_metrics/mjo/lib/lib_mjo.py
+++ b/pcmdi_metrics/mjo/lib/lib_mjo.py
@@ -311,4 +311,4 @@ def mjo_metrics_to_json(outdir, json_filename, result_dict, model=None, run=None
             "model", "realization", "metric"],
         sort_keys=True, indent=4, separators=(',', ': '))
     if cmec_flag:
-            JSON.write_cmec(indent=4, separators=(',', ': '))
+        JSON.write_cmec(indent=4, separators=(',', ': '))

--- a/pcmdi_metrics/mjo/lib/lib_mjo.py
+++ b/pcmdi_metrics/mjo/lib/lib_mjo.py
@@ -284,7 +284,7 @@ def unit_conversion(data, UnitsAdjust):
     return data
 
 
-def mjo_metrics_to_json(outdir, json_filename, result_dict, model=None, run=None):
+def mjo_metrics_to_json(outdir, json_filename, result_dict, model=None, run=None, cmec_flag=False):
     # Open JSON
     JSON = pcmdi_metrics.io.base.Base(
         outdir(output_type='metrics_results'),
@@ -310,3 +310,5 @@ def mjo_metrics_to_json(outdir, json_filename, result_dict, model=None, run=None
         json_structure=[
             "model", "realization", "metric"],
         sort_keys=True, indent=4, separators=(',', ': '))
+    if cmec_flag:
+            JSON.write_cmec(indent=4, separators=(',', ': '))

--- a/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
+++ b/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
@@ -1,4 +1,6 @@
 import cdms2
+import copy
+import matplotlib.cm
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 import os
@@ -23,11 +25,12 @@ def plot_power(d, title, fout, ewr=None):
     # plot
     plt.switch_backend('agg')  # backend plotting
     plt.figure(figsize=(8, 4))
+    cm = copy.copy(matplotlib.cm.get_cmap("jet"))
     cs = plt.contourf(
         x, y, d,
         levels=[0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.016,
                 0.018, 0.020, 0.022, 0.024, 0.026, 0.028, 0.03, 0.032],
-        cmap=plt.get_cmap('jet'),
+        cmap=cm,
         extend='both')
     cs.cmap.set_under('w')
     # y-axis range

--- a/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
+++ b/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
@@ -127,6 +127,12 @@ for output_type in ['graphics', 'diagnostic_results', 'metrics_results']:
         os.makedirs(outdir(output_type=output_type))
     print(outdir(output_type=output_type))
 
+# Generate CMEC compliant json
+cmec = False
+if hasattr(param, 'cmec'):
+    cmec = param.cmec
+print('CMEC: ' + str(cmec))
+
 # Debug
 debug = param.debug
 print('debug: ', debug)
@@ -279,12 +285,14 @@ for model in models:
                                sort_keys=True,
                                indent=4,
                                separators=(',', ': '))
+                    if cmec:
+                        JSON.write_cmec(indent=4, separators=(',', ': '))
                 print('Done')
             except Exception as err:
                 if debug:
                     raise
                 else:
-                    print('warning: faild for ', model, run, err)
+                    print('warning: failed for ', model, run, err)
                     pass
         # --- Realization loop end
 
@@ -292,7 +300,7 @@ for model in models:
         if debug:
             raise
         else:
-            print('warning: faild for ', model, err)
+            print('warning: failed for ', model, err)
             pass
 # --- Model loop end
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ scripts = ['pcmdi_metrics/pcmdi/scripts/mean_climate_driver.py',
            'pcmdi_metrics/misc/scripts/get_pmp_data.py',
            'pcmdi_metrics/monsoon_wang/scripts/mpindex_compute.py',
            'pcmdi_metrics/monsoon_sperber/scripts/driver_monsoon_sperber.py',
+           'pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py'
            ]
 # scripts += glob.glob("pcmdi_metrics/diurnal/scripts/*.py")
 


### PR DESCRIPTION
Summary:
This PR accomplishes 3 things:
1. Add "cmec" flag option to generate cmec-compliant metrics json for MJO package when run in serial (while this is compatible with the parallel case, changes to the parallel driver files have not been implemented).
2. Add the MJO driver script to setup.py so that it is installed to the user's environment.
3. Copy the colormap for use in plot_wavenumber_frequency_power.py in response to a deprecation warning.

Usage:
CMEC output: run mjo package as usual, but either add cmec = True to your parameter file or use --cmec=True in the command line.
MJO driver: From any location with your PMP environment active, use mjo_metrics_driver.py -p name_of_param_file.py