### PR TITLE
Refactor cmec flag

### DIFF
--- a/pcmdi_metrics/mjo/lib/argparse_functions.py
+++ b/pcmdi_metrics/mjo/lib/argparse_functions.py
@@ -116,7 +116,7 @@ def AddParserArgument(P):
                    default=1,
                    help="Start year for model data set")
     # Defaults
-    P.set_defaults(includeOBS=True, parallel=False)
+    P.set_defaults(includeOBS=True, parallel=False, cmec=False)
     return P
 
 

--- a/pcmdi_metrics/mjo/lib/argparse_functions.py
+++ b/pcmdi_metrics/mjo/lib/argparse_functions.py
@@ -95,8 +95,14 @@ def AddParserArgument(P):
                    help="Option for update existing JSON file: True (i.e., update) (default) / False (i.e., overwrite)")
     P.add_argument("--cmec",
                    dest='cmec',
+                   action='store_true',
                    default=False,
-                   help='Option to save metrics in CMEC format: True / False (default)')
+                   help='Option to save metrics in CMEC format')
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help='Option to not save metrics in CMEC format')
     # Parallel
     P.add_argument("--parallel",
                    action="store_true",

--- a/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
+++ b/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
@@ -128,7 +128,6 @@ for output_type in ['graphics', 'diagnostic_results', 'metrics_results']:
     print(outdir(output_type=output_type))
 
 # Generate CMEC compliant json
-cmec = False
 if hasattr(param, 'cmec'):
     cmec = param.cmec
 print('CMEC: ' + str(cmec))

--- a/pcmdi_metrics/pcmdi/mean_climate_metrics_driver.py
+++ b/pcmdi_metrics/pcmdi/mean_climate_metrics_driver.py
@@ -411,7 +411,16 @@ def create_mean_climate_parser():
     parser.add_argument(
         '--cmec',
         dest='cmec',
-        help='True to save metrics in CMEC format',
+        action='store_true',
+        help='Save metrics in CMEC format',
+        default=False,
+        required=False)
+
+    parser.add_argument(
+        '--no_cmec',
+        dest='cmec',
+        action='store_false',
+        help='Option to not save metrics in CMEC format',
         default=False,
         required=False)
 

--- a/pcmdi_metrics/variability_mode/lib/argparse_functions.py
+++ b/pcmdi_metrics/variability_mode/lib/argparse_functions.py
@@ -155,8 +155,14 @@ def AddParserArgument(P):
                    help="Option for update existing JSON file: True (i.e., update) (default) / False (i.e., overwrite)")
     P.add_argument("--cmec",
                    dest='cmec',
+                   action='store_true',
                    default=False,
-                   help='Option to save metrics in CMEC format: True / False (default)')
+                   help='Save metrics in CMEC format')
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help='Option to not save metrics in CMEC format')
     P.set_defaults(nc_out_obs=True, plot_obs=True)
     return P
 


### PR DESCRIPTION
Summary
This PR changes the command-line CMEC flag usage in the **mean climate**, **MJO**, and **modes of variability** metrics. 

Usage
To generate CMEC formatted metrics, users should specify `--cmec` in the command line. To *not* save CMEc formatted metrics, users should specify `--no_cmec` in the command line. In parameter files, continue to use `cmec=True` or `cmec=False` as before.
This change is to avoid having users enter True or False in the command line, which sometimes gets passed as a string (always evaluating to True) rather than a boolean quantity.

Testing
I've run all three metrics, setting the CMEC flag in the parameter file and/or on the command line.