### PR TITLE
Add CMEC formatted metrics to diurnal cycle drivers

### DIFF
--- a/pcmdi_metrics/diurnal/scripts/savg_fourier.py
+++ b/pcmdi_metrics/diurnal/scripts/savg_fourier.py
@@ -51,6 +51,16 @@ def main():
                    default="cmip5.%(model).%(experiment).r0i0p0.fx.atm.fx.sftlf.%(version).latestX.xml",
                    help="template for sftlf file names")
     P.add_argument("--model", default="*")
+    P.add_argument("--cmec",
+                   dest='cmec',
+                   action='store_true',
+                   default=False,
+                   help="Use to save metrics in CMEC JSON format")
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help="Use to disable saving metrics in CMEC JSON format")
 
     args = P.get_parameter()
     month = args.month
@@ -58,6 +68,7 @@ def main():
     startyear = args.firstyear
     finalyear = args.lastyear
     years = "%s-%s" % (startyear, finalyear)  # noqa: F841
+    cmec = args.cmec
 
     print('Specifying latitude / longitude domain of interest ...')
     # TRMM (observed) domain:
@@ -287,6 +298,9 @@ def main():
         separators=(
             ',',
             ': '))
+    if cmec:
+        print("Writing cmec file")
+        OUT.write_cmec(indent=4, separators=(',', ': '))
     print('done')
 
 

--- a/pcmdi_metrics/diurnal/scripts/std_of_dailymeans.py
+++ b/pcmdi_metrics/diurnal/scripts/std_of_dailymeans.py
@@ -83,12 +83,23 @@ def main():
     P.add_argument("-t", "--filename_template",
                    default="pr_%(model)_%(month)_%(firstyear)-%(lastyear)_std_of_dailymeans.nc")
     P.add_argument("--model", default="*")
+    P.add_argument("--cmec",
+                   dest='cmec',
+                   action='store_true',
+                   default=False,
+                   help="Use to save metrics in CMEC JSON format")
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help="Use to disable saving metrics in CMEC JSON format")
 
     args = P.get_parameter()
     month = args.month
     monthname = monthname_d[month]
     startyear = args.firstyear  # noqa: F841
     finalyear = args.lastyear  # noqa: F841
+    cmec = args.cmec
 
     template = populateStringConstructor(args.filename_template, args)
     template.month = monthname
@@ -159,6 +170,9 @@ def main():
         separators=(
             ',',
             ': '))
+    if cmec:
+        print("Writing cmec file")
+        OUT.write_cmec(indent=4, separators=(',', ': '))
     print('done')
 
 

--- a/pcmdi_metrics/diurnal/scripts/std_of_hourlyvalues.py
+++ b/pcmdi_metrics/diurnal/scripts/std_of_hourlyvalues.py
@@ -82,12 +82,23 @@ def main():
     P.add_argument("-t", "--filename_template",
                    default="pr_%(model)_%(month)_%(firstyear)-%(lastyear)_diurnal_std.nc")
     P.add_argument("--model", default="*")
+    P.add_argument("--cmec",
+                   dest='cmec',
+                   action='store_true',
+                   default=False,
+                   help="Use to save metrics in CMEC JSON format")
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help="Use to disable saving metrics in CMEC JSON format")
 
     args = P.get_parameter()
     month = args.month
     monthname = monthname_d[month]
     startyear = args.firstyear  # noqa: F841
     finalyear = args.lastyear  # noqa: F841
+    cmec = args.cmec
 
     template = populateStringConstructor(args.filename_template, args)
     template.month = monthname
@@ -169,6 +180,9 @@ def main():
         separators=(
             ',',
             ': '))
+    if cmec:
+        print("Writing cmec file")
+        OUT.write_cmec(indent=4, separators=(',', ': '))
     print('done')
 
 

--- a/pcmdi_metrics/diurnal/scripts/std_of_meandiurnalcycle.py
+++ b/pcmdi_metrics/diurnal/scripts/std_of_meandiurnalcycle.py
@@ -83,12 +83,23 @@ def main():
     P.add_argument("-t", "--filename_template",
                    default="pr_%(model)_%(month)_%(firstyear)-%(lastyear)_diurnal_avg.nc")
     P.add_argument("--model", default="*")
+    P.add_argument("--cmec",
+                   dest='cmec',
+                   action='store_true',
+                   default=False,
+                   help="Use to save metrics in CMEC JSON format")
+    P.add_argument("--no_cmec",
+                   dest='cmec',
+                   action='store_false',
+                   default=False,
+                   help="Use to disable saving metrics in CMEC JSON format")
 
     args = P.get_parameter()
     month = args.month
     monthname = monthname_d[month]
     startyear = args.firstyear  # noqa: F841
     finalyear = args.lastyear  # noqa: F841
+    cmec = args.cmec
 
     template = populateStringConstructor(args.filename_template, args)
     template.month = monthname
@@ -173,6 +184,9 @@ def main():
         separators=(
             ',',
             ': '))
+    if cmec:
+        print("Writing cmec file")
+        OUT.write_cmec(indent=4, separators=(',', ': '))
     print('done')
 
 


### PR DESCRIPTION
Summary:
This PR adds an option to convert the Diurnal Cycle metrics JSONs to CMEC formatted JSONs. The following scripts have JSON results:
std_of_dailymeans.py
std_of_meandiurnalcycle.py
std_of_hourlyvalues.py
savg_fourier.py

Usage:
Parameter file: use `cmec = True` or `cmec = False`
Command line: use `--cmec` or `--no_cmec`

Testing:
I have run the example cases from the diurnal cycle notebook with the cmec command line and parameter file options.