### PR TITLE
Add cmec flag to Monsoon (Wang)

### DIFF
--- a/pcmdi_metrics/monsoon_wang/monsoon_wang_driver.py
+++ b/pcmdi_metrics/monsoon_wang/monsoon_wang_driver.py
@@ -47,7 +47,17 @@ def create_monsoon_wang_parser():
                    default=2.5 / 86400.,
                    type=float,
                    help="Threshold for a hit when computing skill score")
-
+    P.add_argument("--cmec",
+                    dest="cmec",
+                    default=False,
+                    action="store_true",
+                    help="Use to save CMEC format metrics JSON")
+    P.add_argument("--no_cmec",
+                    dest="cmec",
+                    default=False,
+                    action="store_false",
+                    help="Do not save CMEC format metrics JSON")
+    P.set_defaults(cmec=False)
     return P
 
 
@@ -70,6 +80,9 @@ def monsoon_wang_runner(args):
     var = args.modvar
     thr = args.threshold
     sig_digits = '.3f'
+
+    # Get flag for CMEC output
+    cmec = args.cmec
 
     #########################################
     # PMP monthly default PR obs
@@ -226,3 +239,6 @@ def monsoon_wang_runner(args):
         separators=(
             ',',
             ': '))
+    if cmec:
+        print("Writing cmec file")
+        OUT.write_cmec(indent=4, separators=(',', ': '))

--- a/pcmdi_metrics/monsoon_wang/monsoon_wang_driver.py
+++ b/pcmdi_metrics/monsoon_wang/monsoon_wang_driver.py
@@ -48,15 +48,15 @@ def create_monsoon_wang_parser():
                    type=float,
                    help="Threshold for a hit when computing skill score")
     P.add_argument("--cmec",
-                    dest="cmec",
-                    default=False,
-                    action="store_true",
-                    help="Use to save CMEC format metrics JSON")
+                   dest="cmec",
+                   default=False,
+                   action="store_true",
+                   help="Use to save CMEC format metrics JSON")
     P.add_argument("--no_cmec",
-                    dest="cmec",
-                    default=False,
-                    action="store_false",
-                    help="Do not save CMEC format metrics JSON")
+                   dest="cmec",
+                   default=False,
+                   action="store_false",
+                   help="Do not save CMEC format metrics JSON")
     P.set_defaults(cmec=False)
     return P
 


### PR DESCRIPTION
Summary:
The --cmec flag can now be used to convert the Monsoon (Wang) metrics to CMEC compliant JSONs. 

Usage:
On the command line, use `--cmec` to generate the CMEC JSON or `--no_cmec` to not do the conversion. The conversion is NOT done by default.
In the parameter file, set the variable `cmec` to `True` or `False`.

Testing:
I have run the monsoon wang driver using combinations of the command line flag and parameter file variable and verified that the CMEC metrics conversion was done (or not) as expected.