### PR TITLE
Add notebook descriptions to jupyter doc

### DIFF
--- a/doc/jupyter/Demo/README.md
+++ b/doc/jupyter/Demo/README.md
@@ -21,10 +21,10 @@ The jupyter dashboard will be launched in your browser. From there, navigate to 
 The mean climate notebook contains command line examples that can be copied from the notebook, customized, and run in the terminal. These commands are found in cells with a *%%bash* header.
 
 ## What's in the notebooks  
-Demo 0: Set data and output directories. Download sample data and use cdscan to create xml. Generate parameter files.    
-Demo 1: Run the Mean Climate driver and explore the many options for customization.  
-Demo 1a: Learn how to create annual climatology files for running the mean climate driver with custom data.  
-Demo 2: Run the Monsoon (Wang) driver and its options.  
-Demo 3: Demonstrates the full workflow for running the Diurnal Cycle metrics.  
-Demo 4: Install scipy and eofs in the kernel environment, run the modes of variability driver with the NAM, and view an output image.  
-Demo 5: Run the MJO driver with options and view an output image.  
+[Demo 0](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_0_download_data.ipynb): Set data and output directories. Download sample data and use cdscan to create xml. Generate parameter files.    
+[Demo 1](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_1_mean_climate.ipynb): Run the Mean Climate driver and explore the many options for customization.  
+[Demo 1a](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_1a_compute_climatologies.ipynb): Learn how to create annual climatology files for running the mean climate driver with custom data.  
+[Demo 2](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_2_monsoon_wang.ipynb): Run the Monsoon (Wang) driver and its options.  
+[Demo 3](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_3_diurnal_cycle.ipynb): Demonstrates the full workflow for running the Diurnal Cycle metrics.  
+[Demo 4](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_4_modes_of_variability.ipynb): Install scipy and eofs in the kernel environment, run the modes of variability driver with the NAM, and view an output image.  
+[Demo 5](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_5_mjo_metrics.ipynb): Run the MJO driver with options and view an output image.  

--- a/doc/jupyter/Demo/README.md
+++ b/doc/jupyter/Demo/README.md
@@ -1,6 +1,6 @@
 # Jupyter notebook demos  
 
-These notebooks provide some basic examples for 3 PMP modules (mean climate, monsoon (wang), and diurnal cycle). They demonstrate how to use both input parameter files and the command line to generate metrics. Parameter files are generated from the \*.py.in templates by running the Demo_0_download_data.ipynb notebook.
+These notebooks provide some basic examples for running the PMP metrics modules. They demonstrate how to use both input parameter files and the command line to generate metrics. Parameter files are generated from the \*.py.in templates by running the Demo_0_download_data.ipynb notebook.
 
 ## Environment  
 PCMDI metrics package should be installed. Consult [the documentation](http://pcmdi.github.io/pcmdi_metrics/install-using-anaconda.html) for more help.   

--- a/doc/jupyter/Demo/README.md
+++ b/doc/jupyter/Demo/README.md
@@ -19,3 +19,12 @@ The jupyter dashboard will be launched in your browser. From there, navigate to 
 
 ## Copying commands from notebooks  
 The mean climate notebook contains command line examples that can be copied from the notebook, customized, and run in the terminal. These commands are found in cells with a *%%bash* header.
+
+## What's in the notebooks  
+Demo 0: Set data and output directories. Download sample data and use cdscan to create xml. Generate parameter files.    
+Demo 1: Run the Mean Climate driver and explore the many options for customization.  
+Demo 1a: Learn how to create annual climatology files for running the mean climate driver with custom data.  
+Demo 2: Run the Monsoon (Wang) driver and its options.  
+Demo 3: Demonstrates the full workflow for running the Diurnal Cycle metrics.  
+Demo 4: Install scipy and eofs in the kernel environment, run the modes of variability driver with the NAM, and view an output image.  
+Demo 5: Run the MJO driver with options and view an output image.  

--- a/doc/jupyter/Demo/README.md
+++ b/doc/jupyter/Demo/README.md
@@ -18,7 +18,7 @@ If the notebook is being run on a remote server, [set up an SSH tunnel](https://
 The jupyter dashboard will be launched in your browser. From there, navigate to Demo_0_download_data.ipynb. This notebook must be run first because it populates the demo data and parameter files for the later demos. The other notebooks can be run in any order. For more help with running notebooks, consult the [documentation](https://jupyter.readthedocs.io/en/latest/running.html#running).  
 
 ## Copying commands from notebooks  
-The mean climate notebook contains command line examples that can be copied from the notebook, customized, and run in the terminal. These commands are found in cells with a *%%bash* header.
+The notebooks listed below contain command line examples that can be copied from the notebook, customized, and run in the terminal. These commands are found in cells with a *%%bash* header.
 
 ## What's in the notebooks  
 [Demo 0](https://github.com/PCMDI/pcmdi_metrics/blob/master/doc/jupyter/Demo/Demo_0_download_data.ipynb): Set data and output directories. Download sample data and use cdscan to create xml. Generate parameter files.    


### PR DESCRIPTION
Adds a short description about each notebook to the README. Link each notebook description to the master version of the notebook.