### PR TITLE
Bug fix in CMEC driver climatologies

### DIFF
--- a/cmec/scripts/climatologies.py
+++ b/cmec/scripts/climatologies.py
@@ -22,7 +22,7 @@ def make_climatologies(settings,model_dir,wk_dir):
             model_file.variable = var
             cmd = ["pcmdi_compute_climatologies.py","--infile",model_file(),"--outpath",out_base,"--var",var]
             suffix = "pcmdi_compute_climatologies_{0}_{1}.log".format(model,var)
-            outfilename = os.path.join(out_base,suffx)
+            outfilename = os.path.join(out_base,suffix)
             with open (outfilename,"w") as outfile:
                 subprocess.run(cmd, env=os.environ.copy(), stdout=outfile)
 
@@ -42,13 +42,13 @@ def make_climatologies(settings,model_dir,wk_dir):
 
     # Link sftlf file in AC folder if exists,
     # since it is the new model folder.
-    if settings["generate_sftlf"] is True:
+    if settings["generate_sftlf"] is False:
         sftlf=settings["sftlf_filename_template"]
         s = genutil.StringConstructor(sftlf)
         for model in modellist:
             s.model_verion = model
-            sftlf_src = os.path.join(model_dir,s)
-            sftlf_dst = os.path.join(out_base,s)
+            sftlf_src = os.path.join(model_dir,s())
+            sftlf_dst = os.path.join(out_base,s())
             os.symlink(sftlf_src,sftlf_dst)
 
     return settings

--- a/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
+++ b/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
@@ -82,11 +82,11 @@ def clim_calc(var, infile, outfile, outdir, outfilename, start, end):
     if end_mo_str not in ['11', '12']:
         end_mo_str = '0' + end_mo_str
 
-    d_ac = cdutil.ANNUALCYCLE.climatology(d).astype('Float32')
-    d_djf = cdutil.DJF.climatology(d)(squeeze=1).astype('Float32')
-    d_jja = cdutil.JJA.climatology(d)(squeeze=1).astype('Float32')
-    d_son = cdutil.SON.climatology(d)(squeeze=1).astype('Float32')
-    d_mam = cdutil.MAM.climatology(d)(squeeze=1).astype('Float32')
+    d_ac = cdutil.ANNUALCYCLE.climatology(d).astype('float32')
+    d_djf = cdutil.DJF.climatology(d)(squeeze=1).astype('float32')
+    d_jja = cdutil.JJA.climatology(d)(squeeze=1).astype('float32')
+    d_son = cdutil.SON.climatology(d)(squeeze=1).astype('float32')
+    d_mam = cdutil.MAM.climatology(d)(squeeze=1).astype('float32')
 
     for v in [d_ac, d_djf, d_jja, d_son, d_mam]:
 


### PR DESCRIPTION
This fixes a typo in the CMEC driver automatic climatologies function. This also replaces "Float32" with "float32" as a type in the pcmdi_compute_climatologies script, as "Float32" was not being recognized as a type in Python 3.7.