### PR TITLE
Add calendar months to test JSONs and reactivate tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,18 +144,18 @@ workflows:
                  parameters:
                     os: [ linux, macos ]
               name: build-<< matrix.os >>
-         #- test:
-         #     matrix:
-         #        parameters:
-         #           os: [ linux, macos ]
-         #           py_ver: [ "3.6", "3.7", "3.8" ]
-         #           libnetcdf: [ "nompi", "mpi_mpich", "mpi_openmpi" ]
-         #     name: test-<< matrix.os >>-<< matrix.py_ver >>-<< matrix.libnetcdf >>
-         #     requires:
-         #        - build-<< matrix.os >>
+         - test:
+              matrix:
+                 parameters:
+                    os: [ linux, macos ]
+                    py_ver: [ "3.6", "3.7", "3.8" ]
+                    libnetcdf: [ "nompi", "mpi_mpich", "mpi_openmpi" ]
+              name: test-<< matrix.os >>-<< matrix.py_ver >>-<< matrix.libnetcdf >>
+              requires:
+                 - build-<< matrix.os >>
          - upload:
-              #requires:
-              #   - test
+              requires:
+                 - test
               filters:
                  branches:
                     only: master

--- a/tests/pcmdi/customRegions/tas_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/customRegions/tas_2.5x2.5_regrid2_linear_metrics.json
@@ -24,14 +24,16 @@
                             "son": "-2.401",
                             "mam": "-1.678",
                             "jja": "-1.717",
-                            "djf": "-1.385"
+                            "djf": "-1.385",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.956",
                             "son": "0.98",
                             "mam": "0.75",
                             "jja": "0.94",
-                            "djf": "0.88"
+                            "djf": "0.88",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 300.16387939453125,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "2.401",
                             "mam": "1.678",
                             "jja": "1.717",
-                            "djf": "1.387"
+                            "djf": "1.387",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.442",
                             "son": "299.167",
                             "mam": "299.917",
                             "jja": "299.626",
-                            "djf": "299.062"
+                            "djf": "299.062",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "297.645",
                             "son": "296.766",
                             "mam": "298.240",
                             "jja": "297.909",
-                            "djf": "297.677"
+                            "djf": "297.677",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.088"
@@ -63,7 +68,8 @@
                             "son": "2.414",
                             "mam": "1.729",
                             "jja": "1.745",
-                            "djf": "1.430"
+                            "djf": "1.430",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.882"
@@ -76,7 +82,8 @@
                             "son": "0.253",
                             "mam": "0.418",
                             "jja": "0.310",
-                            "djf": "0.355"
+                            "djf": "0.355",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "1.033",
                             "mam": "0.401",
                             "jja": "0.801",
-                            "djf": "0.727"
+                            "djf": "0.727",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.699"
@@ -97,7 +105,8 @@
                             "son": "1.134",
                             "mam": "0.627",
                             "jja": "0.919",
-                            "djf": "0.688"
+                            "djf": "0.688",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.704"
@@ -112,14 +121,16 @@
                             "son": "-0.862",
                             "mam": "-0.864",
                             "jja": "-0.794",
-                            "djf": "-1.052"
+                            "djf": "-1.052",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.917",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.95",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.509",
                             "mam": "1.229",
                             "jja": "1.283",
-                            "djf": "1.345"
+                            "djf": "1.345",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.828",
                             "son": "297.831",
                             "mam": "298.298",
                             "jja": "297.821",
-                            "djf": "297.367"
+                            "djf": "297.367",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.027",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.113"
@@ -151,7 +165,8 @@
                             "son": "1.921",
                             "mam": "1.593",
                             "jja": "1.569",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.783"
@@ -164,7 +179,8 @@
                             "son": "1.717",
                             "mam": "1.339",
                             "jja": "1.353",
-                            "djf": "1.362"
+                            "djf": "1.362",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "3.280",
                             "mam": "3.177",
                             "jja": "4.237",
-                            "djf": "3.799"
+                            "djf": "3.799",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.219"
@@ -185,7 +202,8 @@
                             "son": "3.459",
                             "mam": "3.202",
                             "jja": "4.111",
-                            "djf": "4.084"
+                            "djf": "4.084",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.015"
@@ -200,14 +218,16 @@
                             "son": "-0.789",
                             "mam": "-0.490",
                             "jja": "-0.526",
-                            "djf": "-0.682"
+                            "djf": "-0.682",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.990",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "1.698",
                             "mam": "1.835",
                             "jja": "1.534",
-                            "djf": "1.993"
+                            "djf": "1.993",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.563",
                             "son": "287.607",
                             "mam": "287.535",
                             "jja": "289.271",
-                            "djf": "285.822"
+                            "djf": "285.822",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.937",
                             "son": "286.818",
                             "mam": "287.046",
                             "jja": "288.745",
-                            "djf": "285.141"
+                            "djf": "285.141",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.394"
@@ -239,7 +262,8 @@
                             "son": "2.181",
                             "mam": "2.467",
                             "jja": "1.997",
-                            "djf": "2.766"
+                            "djf": "2.766",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.466"
@@ -252,7 +276,8 @@
                             "son": "2.033",
                             "mam": "2.418",
                             "jja": "1.927",
-                            "djf": "2.681"
+                            "djf": "2.681",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "14.132",
                             "mam": "14.972",
                             "jja": "14.216",
-                            "djf": "15.868"
+                            "djf": "15.868",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.712"
@@ -273,7 +299,8 @@
                             "son": "14.028",
                             "mam": "14.453",
                             "jja": "13.593",
-                            "djf": "16.022"
+                            "djf": "16.022",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.652"
@@ -288,14 +315,16 @@
                             "son": "-0.723",
                             "mam": "-0.383",
                             "jja": "-0.398",
-                            "djf": "-0.645"
+                            "djf": "-0.645",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.984",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.598876953125,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.569",
                             "mam": "1.696",
                             "jja": "1.370",
-                            "djf": "1.961"
+                            "djf": "1.961",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "289.544",
                             "son": "289.439",
                             "mam": "289.594",
                             "jja": "289.824",
-                            "djf": "289.318"
+                            "djf": "289.318",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "289.341",
                             "son": "289.004",
                             "mam": "289.619",
                             "jja": "289.634",
-                            "djf": "289.115"
+                            "djf": "289.115",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.029"
@@ -327,7 +359,8 @@
                             "son": "1.996",
                             "mam": "2.294",
                             "jja": "1.757",
-                            "djf": "2.804"
+                            "djf": "2.804",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.315"
@@ -340,7 +373,8 @@
                             "son": "1.861",
                             "mam": "2.262",
                             "jja": "1.711",
-                            "djf": "2.729"
+                            "djf": "2.729",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "11.524",
                             "mam": "11.984",
                             "jja": "11.498",
-                            "djf": "12.262"
+                            "djf": "12.262",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.138"
@@ -361,7 +396,8 @@
                             "son": "10.800",
                             "mam": "11.099",
                             "jja": "10.161",
-                            "djf": "12.283"
+                            "djf": "12.283",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.869"
@@ -376,14 +412,16 @@
                             "son": "-2.252",
                             "mam": "-2.243",
                             "jja": "-1.578",
-                            "djf": "-2.539"
+                            "djf": "-2.539",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.983",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.98",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 311.615234375,
                         "mae_xy": {
@@ -391,21 +429,24 @@
                             "son": "2.412",
                             "mam": "2.794",
                             "jja": "1.982",
-                            "djf": "3.276"
+                            "djf": "3.276",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.356",
                             "son": "279.717",
                             "mam": "276.869",
                             "jja": "288.334",
-                            "djf": "268.391"
+                            "djf": "268.391",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.184",
                             "son": "277.465",
                             "mam": "274.625",
                             "jja": "286.756",
-                            "djf": "265.852"
+                            "djf": "265.852",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.936"
@@ -415,7 +456,8 @@
                             "son": "2.908",
                             "mam": "3.386",
                             "jja": "2.381",
-                            "djf": "4.350"
+                            "djf": "4.350",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.478"
@@ -428,7 +470,8 @@
                             "son": "1.840",
                             "mam": "2.536",
                             "jja": "1.783",
-                            "djf": "3.532"
+                            "djf": "3.532",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -436,7 +479,8 @@
                             "son": "11.143",
                             "mam": "11.127",
                             "jja": "8.083",
-                            "djf": "15.100"
+                            "djf": "15.100",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.970"
@@ -449,7 +493,8 @@
                             "son": "11.403",
                             "mam": "10.980",
                             "jja": "8.371",
-                            "djf": "15.124"
+                            "djf": "15.124",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.612"
@@ -464,14 +509,16 @@
                             "son": "-0.718",
                             "mam": "-1.695",
                             "jja": "-0.780",
-                            "djf": "-1.410"
+                            "djf": "-1.410",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.964",
                             "son": "0.92",
                             "mam": "0.97",
                             "jja": "0.91",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 301.6520690917969,
                         "mae_xy": {
@@ -479,21 +526,24 @@
                             "son": "1.387",
                             "mam": "1.825",
                             "jja": "1.441",
-                            "djf": "1.545"
+                            "djf": "1.545",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "296.301",
                             "son": "297.232",
                             "mam": "295.447",
                             "jja": "297.717",
-                            "djf": "294.781"
+                            "djf": "294.781",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "295.153",
                             "son": "296.503",
                             "mam": "293.765",
                             "jja": "296.895",
-                            "djf": "293.422"
+                            "djf": "293.422",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.120"
@@ -503,7 +553,8 @@
                             "son": "1.627",
                             "mam": "2.069",
                             "jja": "1.695",
-                            "djf": "1.794"
+                            "djf": "1.794",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.862"
@@ -516,7 +567,8 @@
                             "son": "1.459",
                             "mam": "1.187",
                             "jja": "1.505",
-                            "djf": "1.109"
+                            "djf": "1.109",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -524,7 +576,8 @@
                             "son": "3.638",
                             "mam": "5.317",
                             "jja": "3.568",
-                            "djf": "5.473"
+                            "djf": "5.473",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.747"
@@ -537,7 +590,8 @@
                             "son": "3.792",
                             "mam": "5.259",
                             "jja": "3.323",
-                            "djf": "5.536"
+                            "djf": "5.536",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.353"
@@ -552,14 +606,16 @@
                             "son": "0.819",
                             "mam": "2.012",
                             "jja": "1.063",
-                            "djf": "1.917"
+                            "djf": "1.917",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "1.00",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.42657470703125,
                         "mae_xy": {
@@ -567,21 +623,24 @@
                             "son": "1.362",
                             "mam": "2.086",
                             "jja": "1.590",
-                            "djf": "2.006"
+                            "djf": "2.006",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.238",
                             "son": "275.051",
                             "mam": "276.677",
                             "jja": "273.107",
-                            "djf": "280.165"
+                            "djf": "280.165",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.696",
                             "son": "275.870",
                             "mam": "278.688",
                             "jja": "274.170",
-                            "djf": "282.082"
+                            "djf": "282.082",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.243"
@@ -591,7 +650,8 @@
                             "son": "1.785",
                             "mam": "2.794",
                             "jja": "2.317",
-                            "djf": "2.400"
+                            "djf": "2.400",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.423"
@@ -604,7 +664,8 @@
                             "son": "1.586",
                             "mam": "1.939",
                             "jja": "2.059",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -612,7 +673,8 @@
                             "son": "14.974",
                             "mam": "17.007",
                             "jja": "17.286",
-                            "djf": "12.162"
+                            "djf": "12.162",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.536"
@@ -625,7 +687,8 @@
                             "son": "14.824",
                             "mam": "15.952",
                             "jja": "16.782",
-                            "djf": "11.554"
+                            "djf": "11.554",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.895"

--- a/tests/pcmdi/customRegions/tos_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/customRegions/tos_2.5x2.5_esmf_linear_metrics.json
@@ -24,14 +24,16 @@
                             "son": "-0.640",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 280.54689315404653,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "1.020",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.282",
                             "son": "299.089",
                             "mam": "299.697",
                             "jja": "299.086",
-                            "djf": "299.264"
+                            "djf": "299.264",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.663",
                             "son": "298.403",
                             "mam": "299.129",
                             "jja": "298.473",
-                            "djf": "298.655"
+                            "djf": "298.655",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -63,7 +68,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.194",
-                            "djf": "1.239"
+                            "djf": "1.239",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.304"
@@ -76,7 +82,8 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "3.043",
                             "mam": "2.567",
                             "jja": "2.988",
-                            "djf": "2.401"
+                            "djf": "2.401",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.570"
@@ -97,7 +105,8 @@
                             "son": "3.062",
                             "mam": "2.615",
                             "jja": "2.940",
-                            "djf": "2.421"
+                            "djf": "2.421",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -112,14 +121,16 @@
                             "son": "-0.407",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.078"
+                            "djf": "0.078",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.042",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.399",
                             "son": "290.975",
                             "mam": "291.700",
                             "jja": "291.237",
-                            "djf": "291.689"
+                            "djf": "291.689",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -151,7 +165,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.346",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -164,7 +179,8 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.317",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "10.000",
                             "mam": "10.090",
                             "jja": "9.904",
-                            "djf": "9.801"
+                            "djf": "9.801",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.742"
@@ -185,7 +202,8 @@
                             "son": "9.667",
                             "mam": "9.596",
                             "jja": "9.527",
-                            "djf": "9.140"
+                            "djf": "9.140",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.695"
@@ -200,14 +218,16 @@
                             "son": "-1.558",
                             "mam": "-1.260",
                             "jja": "-1.071",
-                            "djf": "-1.338"
+                            "djf": "-1.338",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "1.748",
                             "mam": "1.573",
                             "jja": "1.358",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.145",
                             "son": "286.171",
                             "mam": "281.778",
                             "jja": "286.814",
-                            "djf": "281.851"
+                            "djf": "281.851",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.822",
                             "son": "284.586",
                             "mam": "280.490",
                             "jja": "285.644",
-                            "djf": "280.520"
+                            "djf": "280.520",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -239,7 +262,8 @@
                             "son": "2.091",
                             "mam": "1.984",
                             "jja": "1.729",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.047"
@@ -252,7 +276,8 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.357",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "8.621",
                             "mam": "7.338",
                             "jja": "8.743",
-                            "djf": "7.365"
+                            "djf": "7.365",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -273,7 +299,8 @@
                             "son": "8.840",
                             "mam": "7.573",
                             "jja": "8.923",
-                            "djf": "7.627"
+                            "djf": "7.627",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -288,14 +315,16 @@
                             "son": "0.610",
                             "mam": "1.597",
                             "jja": "0.658",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2935035335274,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.040",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.242",
                             "son": "280.972",
                             "mam": "283.285",
                             "jja": "281.088",
-                            "djf": "283.648"
+                            "djf": "283.648",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.468",
                             "son": "281.591",
                             "mam": "284.895",
                             "jja": "281.760",
-                            "djf": "285.660"
+                            "djf": "285.660",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.807"
@@ -327,7 +359,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -340,7 +373,8 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.189",
-                            "djf": "1.337"
+                            "djf": "1.337",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.639"
+                            "djf": "7.639",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -361,7 +396,8 @@
                             "son": "6.448",
                             "mam": "6.993",
                             "jja": "6.438",
-                            "djf": "6.653"
+                            "djf": "6.653",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.591"

--- a/tests/pcmdi/customRegions/tos_2.5x2.5_esmf_linear_metrics.json.mac
+++ b/tests/pcmdi/customRegions/tos_2.5x2.5_esmf_linear_metrics.json.mac
@@ -24,14 +24,16 @@
                             "son": "-0.641",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 280.54689315404653,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "1.021",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.283",
                             "son": "299.089",
                             "mam": "299.698",
                             "jja": "299.085",
-                            "djf": "299.265"
+                            "djf": "299.265",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.664",
                             "son": "298.405",
                             "mam": "299.128",
                             "jja": "298.476",
-                            "djf": "298.654"
+                            "djf": "298.654",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -63,7 +68,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.195",
-                            "djf": "1.240"
+                            "djf": "1.240",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.305"
@@ -76,7 +82,8 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "3.042",
                             "mam": "2.568",
                             "jja": "2.986",
-                            "djf": "2.402"
+                            "djf": "2.402",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.569"
@@ -97,7 +105,8 @@
                             "son": "3.063",
                             "mam": "2.615",
                             "jja": "2.942",
-                            "djf": "2.422"
+                            "djf": "2.422",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -112,14 +121,16 @@
                             "son": "-0.408",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.077"
+                            "djf": "0.077",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.043",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.396",
                             "son": "290.973",
                             "mam": "291.697",
                             "jja": "291.238",
-                            "djf": "291.684"
+                            "djf": "291.684",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -151,7 +165,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.347",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -164,7 +179,8 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.318",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "9.998",
                             "mam": "10.088",
                             "jja": "9.901",
-                            "djf": "9.798"
+                            "djf": "9.798",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.741"
@@ -185,7 +202,8 @@
                             "son": "9.669",
                             "mam": "9.597",
                             "jja": "9.529",
-                            "djf": "9.142"
+                            "djf": "9.142",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.694"
@@ -200,14 +218,16 @@
                             "son": "-1.559",
                             "mam": "-1.260",
                             "jja": "-1.073",
-                            "djf": "-1.339"
+                            "djf": "-1.339",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "1.748",
                             "mam": "1.572",
                             "jja": "1.361",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.155",
                             "son": "286.183",
                             "mam": "281.784",
                             "jja": "286.825",
-                            "djf": "281.859"
+                            "djf": "281.859",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.816",
                             "son": "284.581",
                             "mam": "280.485",
                             "jja": "285.641",
-                            "djf": "280.510"
+                            "djf": "280.510",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -239,7 +262,8 @@
                             "son": "2.092",
                             "mam": "1.983",
                             "jja": "1.732",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.048"
@@ -252,7 +276,8 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.359",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "8.619",
                             "mam": "7.334",
                             "jja": "8.742",
-                            "djf": "7.360"
+                            "djf": "7.360",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -273,7 +299,8 @@
                             "son": "8.836",
                             "mam": "7.570",
                             "jja": "8.920",
-                            "djf": "7.626"
+                            "djf": "7.626",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -288,14 +315,16 @@
                             "son": "0.608",
                             "mam": "1.597",
                             "jja": "0.657",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2935035335274,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.039",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.248",
                             "son": "280.977",
                             "mam": "283.290",
                             "jja": "281.092",
-                            "djf": "283.654"
+                            "djf": "283.654",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.458",
                             "son": "281.581",
                             "mam": "284.885",
                             "jja": "281.751",
-                            "djf": "285.650"
+                            "djf": "285.650",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.806"
@@ -327,7 +359,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -340,7 +373,8 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.190",
-                            "djf": "1.338"
+                            "djf": "1.338",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.638"
+                            "djf": "7.638",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -361,7 +396,8 @@
                             "son": "6.439",
                             "mam": "6.987",
                             "jja": "6.432",
-                            "djf": "6.646"
+                            "djf": "6.646",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.589"

--- a/tests/pcmdi/gensftlfTest/tas_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/gensftlfTest/tas_2.5x2.5_esmf_linear_metrics.json
@@ -24,35 +24,40 @@
                             "son": "-0.882",
                             "mam": "-0.996",
                             "jja": "-1.010",
-                            "djf": "-0.544"
+                            "djf": "-0.544",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.994",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.851",
                             "son": "2.117",
                             "mam": "2.296",
                             "jja": "2.110",
-                            "djf": "2.024"
+                            "djf": "2.024",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.447",
                             "son": "282.829",
                             "mam": "282.319",
                             "jja": "287.841",
-                            "djf": "276.747"
+                            "djf": "276.747",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "281.247",
                             "son": "281.597",
                             "mam": "281.016",
                             "jja": "286.560",
-                            "djf": "275.805"
+                            "djf": "275.805",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.813"
@@ -62,7 +67,8 @@
                             "son": "2.681",
                             "mam": "2.937",
                             "jja": "2.646",
-                            "djf": "2.576"
+                            "djf": "2.576",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.868"
@@ -75,14 +81,16 @@
                             "son": "2.532",
                             "mam": "2.763",
                             "jja": "2.446",
-                            "djf": "2.518"
+                            "djf": "2.518",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "18.682",
                             "son": "18.925",
                             "mam": "20.214",
                             "jja": "20.136",
-                            "djf": "20.168"
+                            "djf": "20.168",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.885"
@@ -95,7 +103,8 @@
                             "son": "19.314",
                             "mam": "19.529",
                             "jja": "20.093",
-                            "djf": "19.575"
+                            "djf": "19.575",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "5.079"
@@ -110,35 +119,40 @@
                             "son": "-0.870",
                             "mam": "-0.872",
                             "jja": "-0.802",
-                            "djf": "-1.060"
+                            "djf": "-1.060",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.912",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.94",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.260",
                             "son": "1.538",
                             "mam": "1.263",
                             "jja": "1.317",
-                            "djf": "1.377"
+                            "djf": "1.377",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.836",
                             "son": "297.839",
                             "mam": "298.306",
                             "jja": "297.828",
-                            "djf": "297.375"
+                            "djf": "297.375",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.026",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.169"
@@ -148,7 +162,8 @@
                             "son": "1.958",
                             "mam": "1.645",
                             "jja": "1.614",
-                            "djf": "1.767"
+                            "djf": "1.767",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.828"
@@ -161,14 +176,16 @@
                             "son": "1.755",
                             "mam": "1.395",
                             "jja": "1.401",
-                            "djf": "1.414"
+                            "djf": "1.414",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "3.033",
                             "son": "3.322",
                             "mam": "3.227",
                             "jja": "4.268",
-                            "djf": "3.842"
+                            "djf": "3.842",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.280"
@@ -181,7 +198,8 @@
                             "son": "3.473",
                             "mam": "3.213",
                             "jja": "4.120",
-                            "djf": "4.093"
+                            "djf": "4.093",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.026"
@@ -196,35 +214,40 @@
                             "son": "-0.787",
                             "mam": "-0.489",
                             "jja": "-0.526",
-                            "djf": "-0.680"
+                            "djf": "-0.680",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.989",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.669",
                             "son": "1.726",
                             "mam": "1.861",
                             "jja": "1.568",
-                            "djf": "2.025"
+                            "djf": "2.025",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.558",
                             "son": "287.602",
                             "mam": "287.530",
                             "jja": "289.266",
-                            "djf": "285.818"
+                            "djf": "285.818",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.933",
                             "son": "286.815",
                             "mam": "287.041",
                             "jja": "288.741",
-                            "djf": "285.138"
+                            "djf": "285.138",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.454"
@@ -234,7 +257,8 @@
                             "son": "2.219",
                             "mam": "2.505",
                             "jja": "2.051",
-                            "djf": "2.805"
+                            "djf": "2.805",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.508"
@@ -247,14 +271,16 @@
                             "son": "2.075",
                             "mam": "2.457",
                             "jja": "1.983",
-                            "djf": "2.721"
+                            "djf": "2.721",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "14.108",
                             "son": "14.163",
                             "mam": "15.003",
                             "jja": "14.244",
-                            "djf": "15.898"
+                            "djf": "15.898",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.769"
@@ -267,7 +293,8 @@
                             "son": "14.042",
                             "mam": "14.468",
                             "jja": "13.608",
-                            "djf": "16.032"
+                            "djf": "16.032",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.670"
@@ -282,35 +309,40 @@
                             "son": "-0.708",
                             "mam": "-0.344",
                             "jja": "-0.373",
-                            "djf": "-0.602"
+                            "djf": "-0.602",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.984",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.589",
                             "son": "1.576",
                             "mam": "1.680",
                             "jja": "1.368",
-                            "djf": "1.956"
+                            "djf": "1.956",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "289.707",
                             "son": "289.525",
                             "mam": "289.836",
                             "jja": "289.780",
-                            "djf": "289.691"
+                            "djf": "289.691",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "289.235",
                             "son": "288.839",
                             "mam": "289.545",
                             "jja": "289.412",
-                            "djf": "289.152"
+                            "djf": "289.152",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.992"
@@ -320,7 +352,8 @@
                             "son": "2.003",
                             "mam": "2.281",
                             "jja": "1.775",
-                            "djf": "2.784"
+                            "djf": "2.784",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.309"
@@ -333,14 +366,16 @@
                             "son": "1.873",
                             "mam": "2.255",
                             "jja": "1.735",
-                            "djf": "2.718"
+                            "djf": "2.718",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "11.197",
                             "son": "11.325",
                             "mam": "11.626",
                             "jja": "11.347",
-                            "djf": "11.743"
+                            "djf": "11.743",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.044"
@@ -353,7 +388,8 @@
                             "son": "10.865",
                             "mam": "11.109",
                             "jja": "10.334",
-                            "djf": "12.107"
+                            "djf": "12.107",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.810"
@@ -368,35 +404,40 @@
                             "son": "-2.236",
                             "mam": "-2.226",
                             "jja": "-1.562",
-                            "djf": "-2.525"
+                            "djf": "-2.525",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.982",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.97",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.471",
                             "son": "2.441",
                             "mam": "2.821",
                             "jja": "2.026",
-                            "djf": "3.324"
+                            "djf": "3.324",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.335",
                             "son": "279.695",
                             "mam": "276.844",
                             "jja": "288.315",
-                            "djf": "268.370"
+                            "djf": "268.370",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.179",
                             "son": "277.459",
                             "mam": "274.619",
                             "jja": "286.752",
-                            "djf": "265.845"
+                            "djf": "265.845",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "2.012"
@@ -406,7 +447,8 @@
                             "son": "2.950",
                             "mam": "3.427",
                             "jja": "2.464",
-                            "djf": "4.394"
+                            "djf": "4.394",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.527"
@@ -419,14 +461,16 @@
                             "son": "1.924",
                             "mam": "2.606",
                             "jja": "1.906",
-                            "djf": "3.596"
+                            "djf": "3.596",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "10.873",
                             "son": "11.178",
                             "mam": "11.155",
                             "jja": "8.120",
-                            "djf": "15.134"
+                            "djf": "15.134",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "5.044"
@@ -439,7 +483,8 @@
                             "son": "11.413",
                             "mam": "10.992",
                             "jja": "8.384",
-                            "djf": "15.136"
+                            "djf": "15.136",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.633"
@@ -454,35 +499,40 @@
                             "son": "0.826",
                             "mam": "2.015",
                             "jja": "1.064",
-                            "djf": "1.926"
+                            "djf": "1.926",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.684",
                             "son": "1.387",
                             "mam": "2.096",
                             "jja": "1.612",
-                            "djf": "2.023"
+                            "djf": "2.023",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.225",
                             "son": "275.036",
                             "mam": "276.663",
                             "jja": "273.095",
-                            "djf": "280.151"
+                            "djf": "280.151",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.687",
                             "son": "275.862",
                             "mam": "278.678",
                             "jja": "274.159",
-                            "djf": "282.077"
+                            "djf": "282.077",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.293"
@@ -492,7 +542,8 @@
                             "son": "1.826",
                             "mam": "2.818",
                             "jja": "2.356",
-                            "djf": "2.432"
+                            "djf": "2.432",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.456"
@@ -505,14 +556,16 @@
                             "son": "1.629",
                             "mam": "1.970",
                             "jja": "2.102",
-                            "djf": "1.485"
+                            "djf": "1.485",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "15.321",
                             "son": "15.010",
                             "mam": "17.048",
                             "jja": "17.324",
-                            "djf": "12.198"
+                            "djf": "12.198",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.580"
@@ -525,7 +578,8 @@
                             "son": "14.852",
                             "mam": "15.984",
                             "jja": "16.812",
-                            "djf": "11.581"
+                            "djf": "11.581",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.921"

--- a/tests/pcmdi/installationTest/tas_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/installationTest/tas_2.5x2.5_regrid2_linear_metrics.json
@@ -24,14 +24,16 @@
                             "son": "-0.789",
                             "mam": "-0.490",
                             "jja": "-0.526",
-                            "djf": "-0.682"
+                            "djf": "-0.682",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.990",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "1.698",
                             "mam": "1.835",
                             "jja": "1.534",
-                            "djf": "1.993"
+                            "djf": "1.993",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.563",
                             "son": "287.607",
                             "mam": "287.535",
                             "jja": "289.271",
-                            "djf": "285.822"
+                            "djf": "285.822",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.937",
                             "son": "286.818",
                             "mam": "287.046",
                             "jja": "288.745",
-                            "djf": "285.141"
+                            "djf": "285.141",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.394"
@@ -63,7 +68,8 @@
                             "son": "2.181",
                             "mam": "2.467",
                             "jja": "1.997",
-                            "djf": "2.766"
+                            "djf": "2.766",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.466"
@@ -76,7 +82,8 @@
                             "son": "2.033",
                             "mam": "2.418",
                             "jja": "1.927",
-                            "djf": "2.681"
+                            "djf": "2.681",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "14.132",
                             "mam": "14.972",
                             "jja": "14.216",
-                            "djf": "15.868"
+                            "djf": "15.868",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.712"
@@ -97,7 +105,8 @@
                             "son": "14.028",
                             "mam": "14.453",
                             "jja": "13.593",
-                            "djf": "16.022"
+                            "djf": "16.022",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.652"
@@ -112,14 +121,16 @@
                             "son": "-0.862",
                             "mam": "-0.864",
                             "jja": "-0.794",
-                            "djf": "-1.052"
+                            "djf": "-1.052",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.917",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.95",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.509",
                             "mam": "1.229",
                             "jja": "1.283",
-                            "djf": "1.345"
+                            "djf": "1.345",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.828",
                             "son": "297.831",
                             "mam": "298.298",
                             "jja": "297.821",
-                            "djf": "297.367"
+                            "djf": "297.367",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.027",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.113"
@@ -151,7 +165,8 @@
                             "son": "1.921",
                             "mam": "1.593",
                             "jja": "1.569",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.783"
@@ -164,7 +179,8 @@
                             "son": "1.717",
                             "mam": "1.339",
                             "jja": "1.353",
-                            "djf": "1.362"
+                            "djf": "1.362",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "3.280",
                             "mam": "3.177",
                             "jja": "4.237",
-                            "djf": "3.799"
+                            "djf": "3.799",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.219"
@@ -185,7 +202,8 @@
                             "son": "3.459",
                             "mam": "3.202",
                             "jja": "4.111",
-                            "djf": "4.084"
+                            "djf": "4.084",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.015"
@@ -200,14 +218,16 @@
                             "son": "-1.032",
                             "mam": "-0.980",
                             "jja": "-1.086",
-                            "djf": "-0.735"
+                            "djf": "-0.735",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.993",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 313.48736572265625,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "2.173",
                             "mam": "2.321",
                             "jja": "2.075",
-                            "djf": "2.123"
+                            "djf": "2.123",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.539",
                             "son": "282.965",
                             "mam": "282.315",
                             "jja": "287.861",
-                            "djf": "276.961"
+                            "djf": "276.961",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "281.569",
                             "son": "281.908",
                             "mam": "281.384",
                             "jja": "286.736",
-                            "djf": "276.237"
+                            "djf": "276.237",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.807"
@@ -239,7 +262,8 @@
                             "son": "2.722",
                             "mam": "2.950",
                             "jja": "2.597",
-                            "djf": "2.709"
+                            "djf": "2.709",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.899"
@@ -252,7 +276,8 @@
                             "son": "2.518",
                             "mam": "2.782",
                             "jja": "2.359",
-                            "djf": "2.607"
+                            "djf": "2.607",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "18.466",
                             "mam": "19.788",
                             "jja": "19.450",
-                            "djf": "20.037"
+                            "djf": "20.037",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.780"
@@ -273,7 +299,8 @@
                             "son": "18.806",
                             "mam": "19.052",
                             "jja": "19.448",
-                            "djf": "19.421"
+                            "djf": "19.421",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "5.026"
@@ -288,14 +315,16 @@
                             "son": "-0.723",
                             "mam": "-0.383",
                             "jja": "-0.398",
-                            "djf": "-0.645"
+                            "djf": "-0.645",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.984",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.598876953125,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.569",
                             "mam": "1.696",
                             "jja": "1.370",
-                            "djf": "1.961"
+                            "djf": "1.961",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "289.544",
                             "son": "289.439",
                             "mam": "289.594",
                             "jja": "289.824",
-                            "djf": "289.318"
+                            "djf": "289.318",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "289.341",
                             "son": "289.004",
                             "mam": "289.619",
                             "jja": "289.634",
-                            "djf": "289.115"
+                            "djf": "289.115",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.029"
@@ -327,7 +359,8 @@
                             "son": "1.996",
                             "mam": "2.294",
                             "jja": "1.757",
-                            "djf": "2.804"
+                            "djf": "2.804",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.315"
@@ -340,7 +373,8 @@
                             "son": "1.861",
                             "mam": "2.262",
                             "jja": "1.711",
-                            "djf": "2.729"
+                            "djf": "2.729",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "11.524",
                             "mam": "11.984",
                             "jja": "11.498",
-                            "djf": "12.262"
+                            "djf": "12.262",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.138"
@@ -361,7 +396,8 @@
                             "son": "10.800",
                             "mam": "11.099",
                             "jja": "10.161",
-                            "djf": "12.283"
+                            "djf": "12.283",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.869"
@@ -376,14 +412,16 @@
                             "son": "-2.252",
                             "mam": "-2.243",
                             "jja": "-1.578",
-                            "djf": "-2.539"
+                            "djf": "-2.539",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.983",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.98",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 311.615234375,
                         "mae_xy": {
@@ -391,21 +429,24 @@
                             "son": "2.412",
                             "mam": "2.794",
                             "jja": "1.982",
-                            "djf": "3.276"
+                            "djf": "3.276",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.356",
                             "son": "279.717",
                             "mam": "276.869",
                             "jja": "288.334",
-                            "djf": "268.391"
+                            "djf": "268.391",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.184",
                             "son": "277.465",
                             "mam": "274.625",
                             "jja": "286.756",
-                            "djf": "265.852"
+                            "djf": "265.852",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.936"
@@ -415,7 +456,8 @@
                             "son": "2.908",
                             "mam": "3.386",
                             "jja": "2.381",
-                            "djf": "4.350"
+                            "djf": "4.350",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.478"
@@ -428,7 +470,8 @@
                             "son": "1.840",
                             "mam": "2.536",
                             "jja": "1.783",
-                            "djf": "3.532"
+                            "djf": "3.532",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -436,7 +479,8 @@
                             "son": "11.143",
                             "mam": "11.127",
                             "jja": "8.083",
-                            "djf": "15.100"
+                            "djf": "15.100",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.970"
@@ -449,7 +493,8 @@
                             "son": "11.403",
                             "mam": "10.980",
                             "jja": "8.371",
-                            "djf": "15.124"
+                            "djf": "15.124",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.612"
@@ -464,14 +509,16 @@
                             "son": "0.819",
                             "mam": "2.012",
                             "jja": "1.063",
-                            "djf": "1.917"
+                            "djf": "1.917",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "1.00",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.42657470703125,
                         "mae_xy": {
@@ -479,21 +526,24 @@
                             "son": "1.362",
                             "mam": "2.086",
                             "jja": "1.590",
-                            "djf": "2.006"
+                            "djf": "2.006",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.238",
                             "son": "275.051",
                             "mam": "276.677",
                             "jja": "273.107",
-                            "djf": "280.165"
+                            "djf": "280.165",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.696",
                             "son": "275.870",
                             "mam": "278.688",
                             "jja": "274.170",
-                            "djf": "282.082"
+                            "djf": "282.082",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.243"
@@ -503,7 +553,8 @@
                             "son": "1.785",
                             "mam": "2.794",
                             "jja": "2.317",
-                            "djf": "2.400"
+                            "djf": "2.400",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.423"
@@ -516,7 +567,8 @@
                             "son": "1.586",
                             "mam": "1.939",
                             "jja": "2.059",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -524,7 +576,8 @@
                             "son": "14.974",
                             "mam": "17.007",
                             "jja": "17.286",
-                            "djf": "12.162"
+                            "djf": "12.162",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.536"
@@ -537,7 +590,8 @@
                             "son": "14.824",
                             "mam": "15.952",
                             "jja": "16.782",
-                            "djf": "11.554"
+                            "djf": "11.554",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.895"

--- a/tests/pcmdi/installationTest/tos_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/installationTest/tos_2.5x2.5_esmf_linear_metrics.json
@@ -24,14 +24,16 @@
                             "son": "-0.640",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 280.54689315404653,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "1.020",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.282",
                             "son": "299.089",
                             "mam": "299.697",
                             "jja": "299.086",
-                            "djf": "299.264"
+                            "djf": "299.264",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.663",
                             "son": "298.403",
                             "mam": "299.129",
                             "jja": "298.473",
-                            "djf": "298.655"
+                            "djf": "298.655",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -63,7 +68,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.194",
-                            "djf": "1.239"
+                            "djf": "1.239",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.304"
@@ -76,7 +82,8 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "3.043",
                             "mam": "2.567",
                             "jja": "2.988",
-                            "djf": "2.401"
+                            "djf": "2.401",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.570"
@@ -97,7 +105,8 @@
                             "son": "3.062",
                             "mam": "2.615",
                             "jja": "2.940",
-                            "djf": "2.421"
+                            "djf": "2.421",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -112,14 +121,16 @@
                             "son": "-0.407",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.078"
+                            "djf": "0.078",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.042",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.399",
                             "son": "290.975",
                             "mam": "291.700",
                             "jja": "291.237",
-                            "djf": "291.689"
+                            "djf": "291.689",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -151,7 +165,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.346",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -164,7 +179,8 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.317",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "10.000",
                             "mam": "10.090",
                             "jja": "9.904",
-                            "djf": "9.801"
+                            "djf": "9.801",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.742"
@@ -185,7 +202,8 @@
                             "son": "9.667",
                             "mam": "9.596",
                             "jja": "9.527",
-                            "djf": "9.140"
+                            "djf": "9.140",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.695"
@@ -200,14 +218,16 @@
                             "son": "-1.558",
                             "mam": "-1.260",
                             "jja": "-1.071",
-                            "djf": "-1.338"
+                            "djf": "-1.338",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "1.748",
                             "mam": "1.573",
                             "jja": "1.358",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.145",
                             "son": "286.171",
                             "mam": "281.778",
                             "jja": "286.814",
-                            "djf": "281.851"
+                            "djf": "281.851",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.822",
                             "son": "284.586",
                             "mam": "280.490",
                             "jja": "285.644",
-                            "djf": "280.520"
+                            "djf": "280.520",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -239,7 +262,8 @@
                             "son": "2.091",
                             "mam": "1.984",
                             "jja": "1.729",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.047"
@@ -252,7 +276,8 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.357",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "8.621",
                             "mam": "7.338",
                             "jja": "8.743",
-                            "djf": "7.365"
+                            "djf": "7.365",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -273,7 +299,8 @@
                             "son": "8.840",
                             "mam": "7.573",
                             "jja": "8.923",
-                            "djf": "7.627"
+                            "djf": "7.627",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -288,14 +315,16 @@
                             "son": "0.610",
                             "mam": "1.597",
                             "jja": "0.658",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2935035335274,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.040",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.242",
                             "son": "280.972",
                             "mam": "283.285",
                             "jja": "281.088",
-                            "djf": "283.648"
+                            "djf": "283.648",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.468",
                             "son": "281.591",
                             "mam": "284.895",
                             "jja": "281.760",
-                            "djf": "285.660"
+                            "djf": "285.660",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.807"
@@ -327,7 +359,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -340,7 +373,8 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.189",
-                            "djf": "1.337"
+                            "djf": "1.337",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.639"
+                            "djf": "7.639",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -361,7 +396,8 @@
                             "son": "6.448",
                             "mam": "6.993",
                             "jja": "6.438",
-                            "djf": "6.653"
+                            "djf": "6.653",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.591"

--- a/tests/pcmdi/installationTest/tos_2.5x2.5_esmf_linear_metrics.json.mac
+++ b/tests/pcmdi/installationTest/tos_2.5x2.5_esmf_linear_metrics.json.mac
@@ -24,14 +24,16 @@
                             "son": "-0.641",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 280.54689315404653,
                         "mae_xy": {
@@ -39,21 +41,24 @@
                             "son": "1.021",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.283",
                             "son": "299.089",
                             "mam": "299.698",
                             "jja": "299.085",
-                            "djf": "299.265"
+                            "djf": "299.265",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.664",
                             "son": "298.405",
                             "mam": "299.128",
                             "jja": "298.476",
-                            "djf": "298.654"
+                            "djf": "298.654",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -63,7 +68,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.195",
-                            "djf": "1.240"
+                            "djf": "1.240",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.305"
@@ -76,7 +82,8 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -84,7 +91,8 @@
                             "son": "3.042",
                             "mam": "2.568",
                             "jja": "2.986",
-                            "djf": "2.402"
+                            "djf": "2.402",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.569"
@@ -97,7 +105,8 @@
                             "son": "3.063",
                             "mam": "2.615",
                             "jja": "2.942",
-                            "djf": "2.422"
+                            "djf": "2.422",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -112,14 +121,16 @@
                             "son": "-0.408",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.077"
+                            "djf": "0.077",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -127,21 +138,24 @@
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.043",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.396",
                             "son": "290.973",
                             "mam": "291.697",
                             "jja": "291.238",
-                            "djf": "291.684"
+                            "djf": "291.684",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -151,7 +165,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.347",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -164,7 +179,8 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.318",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -172,7 +188,8 @@
                             "son": "9.998",
                             "mam": "10.088",
                             "jja": "9.901",
-                            "djf": "9.798"
+                            "djf": "9.798",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.741"
@@ -185,7 +202,8 @@
                             "son": "9.669",
                             "mam": "9.597",
                             "jja": "9.529",
-                            "djf": "9.142"
+                            "djf": "9.142",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.694"
@@ -200,14 +218,16 @@
                             "son": "-1.559",
                             "mam": "-1.260",
                             "jja": "-1.073",
-                            "djf": "-1.339"
+                            "djf": "-1.339",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2738442661475,
                         "mae_xy": {
@@ -215,21 +235,24 @@
                             "son": "1.748",
                             "mam": "1.572",
                             "jja": "1.361",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.155",
                             "son": "286.183",
                             "mam": "281.784",
                             "jja": "286.825",
-                            "djf": "281.859"
+                            "djf": "281.859",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.816",
                             "son": "284.581",
                             "mam": "280.485",
                             "jja": "285.641",
-                            "djf": "280.510"
+                            "djf": "280.510",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -239,7 +262,8 @@
                             "son": "2.092",
                             "mam": "1.983",
                             "jja": "1.732",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.048"
@@ -252,7 +276,8 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.359",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -260,7 +285,8 @@
                             "son": "8.619",
                             "mam": "7.334",
                             "jja": "8.742",
-                            "djf": "7.360"
+                            "djf": "7.360",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -273,7 +299,8 @@
                             "son": "8.836",
                             "mam": "7.570",
                             "jja": "8.920",
-                            "djf": "7.626"
+                            "djf": "7.626",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -288,14 +315,16 @@
                             "son": "0.608",
                             "mam": "1.597",
                             "jja": "0.657",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_ref_min": 271.2935035335274,
                         "mae_xy": {
@@ -303,21 +332,24 @@
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.039",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.248",
                             "son": "280.977",
                             "mam": "283.290",
                             "jja": "281.092",
-                            "djf": "283.654"
+                            "djf": "283.654",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.458",
                             "son": "281.581",
                             "mam": "284.885",
                             "jja": "281.751",
-                            "djf": "285.650"
+                            "djf": "285.650",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.806"
@@ -327,7 +359,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -340,7 +373,8 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.190",
-                            "djf": "1.338"
+                            "djf": "1.338",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -348,7 +382,8 @@
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.638"
+                            "djf": "7.638",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -361,7 +396,8 @@
                             "son": "6.439",
                             "mam": "6.987",
                             "jja": "6.432",
-                            "djf": "6.646"
+                            "djf": "6.646",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.589"

--- a/tests/pcmdi/keep_going_on_error_varnameTest/tos_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/keep_going_on_error_varnameTest/tos_2.5x2.5_esmf_linear_metrics.json
@@ -24,35 +24,40 @@
                             "son": "-0.640",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.887",
                             "son": "1.020",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.282",
                             "son": "299.089",
                             "mam": "299.697",
                             "jja": "299.086",
-                            "djf": "299.264"
+                            "djf": "299.264",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.663",
                             "son": "298.403",
                             "mam": "299.129",
                             "jja": "298.473",
-                            "djf": "298.655"
+                            "djf": "298.655",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -62,7 +67,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.194",
-                            "djf": "1.239"
+                            "djf": "1.239",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.304"
@@ -75,14 +81,16 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.493",
                             "son": "3.043",
                             "mam": "2.567",
                             "jja": "2.988",
-                            "djf": "2.401"
+                            "djf": "2.401",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.570"
@@ -95,7 +103,8 @@
                             "son": "3.062",
                             "mam": "2.615",
                             "jja": "2.940",
-                            "djf": "2.421"
+                            "djf": "2.421",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -110,35 +119,40 @@
                             "son": "-0.407",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.078"
+                            "djf": "0.078",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.142",
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.042",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.399",
                             "son": "290.975",
                             "mam": "291.700",
                             "jja": "291.237",
-                            "djf": "291.689"
+                            "djf": "291.689",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -148,7 +162,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.346",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -161,14 +176,16 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.317",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "9.825",
                             "son": "10.000",
                             "mam": "10.090",
                             "jja": "9.904",
-                            "djf": "9.801"
+                            "djf": "9.801",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.742"
@@ -181,7 +198,8 @@
                             "son": "9.667",
                             "mam": "9.596",
                             "jja": "9.527",
-                            "djf": "9.140"
+                            "djf": "9.140",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.695"
@@ -196,35 +214,40 @@
                             "son": "-1.558",
                             "mam": "-1.260",
                             "jja": "-1.071",
-                            "djf": "-1.338"
+                            "djf": "-1.338",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.529",
                             "son": "1.748",
                             "mam": "1.573",
                             "jja": "1.358",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.145",
                             "son": "286.171",
                             "mam": "281.778",
                             "jja": "286.814",
-                            "djf": "281.851"
+                            "djf": "281.851",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.822",
                             "son": "284.586",
                             "mam": "280.490",
                             "jja": "285.644",
-                            "djf": "280.520"
+                            "djf": "280.520",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -234,7 +257,8 @@
                             "son": "2.091",
                             "mam": "1.984",
                             "jja": "1.729",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.047"
@@ -247,14 +271,16 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.357",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "7.952",
                             "son": "8.621",
                             "mam": "7.338",
                             "jja": "8.743",
-                            "djf": "7.365"
+                            "djf": "7.365",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -267,7 +293,8 @@
                             "son": "8.840",
                             "mam": "7.573",
                             "jja": "8.923",
-                            "djf": "7.627"
+                            "djf": "7.627",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -282,35 +309,40 @@
                             "son": "0.610",
                             "mam": "1.597",
                             "jja": "0.658",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.374",
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.040",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.242",
                             "son": "280.972",
                             "mam": "283.285",
                             "jja": "281.088",
-                            "djf": "283.648"
+                            "djf": "283.648",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.468",
                             "son": "281.591",
                             "mam": "284.895",
                             "jja": "281.760",
-                            "djf": "285.660"
+                            "djf": "285.660",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.807"
@@ -320,7 +352,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -333,14 +366,16 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.189",
-                            "djf": "1.337"
+                            "djf": "1.337",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "7.168",
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.639"
+                            "djf": "7.639",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -353,7 +388,8 @@
                             "son": "6.448",
                             "mam": "6.993",
                             "jja": "6.438",
-                            "djf": "6.653"
+                            "djf": "6.653",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.591"

--- a/tests/pcmdi/keep_going_on_error_varnameTest/tos_2.5x2.5_esmf_linear_metrics.json.mac
+++ b/tests/pcmdi/keep_going_on_error_varnameTest/tos_2.5x2.5_esmf_linear_metrics.json.mac
@@ -24,35 +24,40 @@
                             "son": "-0.641",
                             "mam": "-0.552",
                             "jja": "-0.572",
-                            "djf": "-0.599"
+                            "djf": "-0.599",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.928",
                             "son": "0.93",
                             "mam": "0.90",
                             "jja": "0.94",
-                            "djf": "0.90"
+                            "djf": "0.90",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.888",
                             "son": "1.021",
                             "mam": "0.999",
                             "jja": "0.946",
-                            "djf": "0.995"
+                            "djf": "0.995",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "299.283",
                             "son": "299.089",
                             "mam": "299.698",
                             "jja": "299.085",
-                            "djf": "299.265"
+                            "djf": "299.265",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "298.664",
                             "son": "298.405",
                             "mam": "299.128",
                             "jja": "298.476",
-                            "djf": "298.654"
+                            "djf": "298.654",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.874"
@@ -62,7 +67,8 @@
                             "son": "1.285",
                             "mam": "1.300",
                             "jja": "1.195",
-                            "djf": "1.240"
+                            "djf": "1.240",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.305"
@@ -75,14 +81,16 @@
                             "son": "1.114",
                             "mam": "1.177",
                             "jja": "1.049",
-                            "djf": "1.085"
+                            "djf": "1.085",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.493",
                             "son": "3.042",
                             "mam": "2.568",
                             "jja": "2.986",
-                            "djf": "2.402"
+                            "djf": "2.402",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.569"
@@ -95,7 +103,8 @@
                             "son": "3.063",
                             "mam": "2.615",
                             "jja": "2.942",
-                            "djf": "2.422"
+                            "djf": "2.422",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.414"
@@ -110,35 +119,40 @@
                             "son": "-0.408",
                             "mam": "-0.009",
                             "jja": "-0.277",
-                            "djf": "0.077"
+                            "djf": "0.077",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.991",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.98"
+                            "djf": "0.98",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.142",
                             "son": "1.144",
                             "mam": "1.288",
                             "jja": "1.043",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "291.581",
                             "son": "291.440",
                             "mam": "291.719",
                             "jja": "291.582",
-                            "djf": "291.612"
+                            "djf": "291.612",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "291.396",
                             "son": "290.973",
                             "mam": "291.697",
                             "jja": "291.238",
-                            "djf": "291.684"
+                            "djf": "291.684",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.907"
@@ -148,7 +162,8 @@
                             "son": "1.465",
                             "mam": "1.627",
                             "jja": "1.347",
-                            "djf": "1.835"
+                            "djf": "1.835",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.625"
@@ -161,14 +176,16 @@
                             "son": "1.407",
                             "mam": "1.627",
                             "jja": "1.318",
-                            "djf": "1.833"
+                            "djf": "1.833",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "9.822",
                             "son": "9.998",
                             "mam": "10.088",
                             "jja": "9.901",
-                            "djf": "9.798"
+                            "djf": "9.798",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.741"
@@ -181,7 +198,8 @@
                             "son": "9.669",
                             "mam": "9.597",
                             "jja": "9.529",
-                            "djf": "9.142"
+                            "djf": "9.142",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.694"
@@ -196,35 +214,40 @@
                             "son": "-1.559",
                             "mam": "-1.260",
                             "jja": "-1.073",
-                            "djf": "-1.339"
+                            "djf": "-1.339",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.986",
                             "son": "0.99",
                             "mam": "0.98",
                             "jja": "0.99",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.530",
                             "son": "1.748",
                             "mam": "1.572",
                             "jja": "1.361",
-                            "djf": "1.745"
+                            "djf": "1.745",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "284.155",
                             "son": "286.183",
                             "mam": "281.784",
                             "jja": "286.825",
-                            "djf": "281.859"
+                            "djf": "281.859",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "282.816",
                             "son": "284.581",
                             "mam": "280.485",
                             "jja": "285.641",
-                            "djf": "280.510"
+                            "djf": "280.510",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.154"
@@ -234,7 +257,8 @@
                             "son": "2.092",
                             "mam": "1.983",
                             "jja": "1.732",
-                            "djf": "2.180"
+                            "djf": "2.180",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.048"
@@ -247,14 +271,16 @@
                             "son": "1.395",
                             "mam": "1.532",
                             "jja": "1.359",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "7.949",
                             "son": "8.619",
                             "mam": "7.334",
                             "jja": "8.742",
-                            "djf": "7.360"
+                            "djf": "7.360",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.439"
@@ -267,7 +293,8 @@
                             "son": "8.836",
                             "mam": "7.570",
                             "jja": "8.920",
-                            "djf": "7.626"
+                            "djf": "7.626",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.515"
@@ -282,35 +309,40 @@
                             "son": "0.608",
                             "mam": "1.597",
                             "jja": "0.657",
-                            "djf": "2.001"
+                            "djf": "2.001",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.992",
                             "son": "0.98",
                             "mam": "0.99",
                             "jja": "0.98",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.374",
                             "son": "1.035",
                             "mam": "1.637",
                             "jja": "1.039",
-                            "djf": "2.059"
+                            "djf": "2.059",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.248",
                             "son": "280.977",
                             "mam": "283.290",
                             "jja": "281.092",
-                            "djf": "283.654"
+                            "djf": "283.654",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "283.458",
                             "son": "281.581",
                             "mam": "284.885",
                             "jja": "281.751",
-                            "djf": "285.650"
+                            "djf": "285.650",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.806"
@@ -320,7 +352,8 @@
                             "son": "1.346",
                             "mam": "1.901",
                             "jja": "1.359",
-                            "djf": "2.407"
+                            "djf": "2.407",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.854"
@@ -333,14 +366,16 @@
                             "son": "1.200",
                             "mam": "1.032",
                             "jja": "1.190",
-                            "djf": "1.338"
+                            "djf": "1.338",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "7.168",
                             "son": "6.773",
                             "mam": "7.589",
                             "jja": "6.712",
-                            "djf": "7.638"
+                            "djf": "7.638",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.545"
@@ -353,7 +388,8 @@
                             "son": "6.439",
                             "mam": "6.987",
                             "jja": "6.432",
-                            "djf": "6.646"
+                            "djf": "6.646",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.589"

--- a/tests/pcmdi/level_data/ta-200_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/level_data/ta-200_2.5x2.5_regrid2_linear_metrics.json
@@ -24,35 +24,40 @@
                             "son": "-1.297",
                             "mam": "-1.059",
                             "jja": "-1.822",
-                            "djf": "-1.386"
+                            "djf": "-1.386",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.772",
                             "son": "0.77",
                             "mam": "0.72",
                             "jja": "0.77",
-                            "djf": "0.61"
+                            "djf": "0.61",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.414",
                             "son": "1.316",
                             "mam": "1.182",
                             "jja": "1.838",
-                            "djf": "1.470"
+                            "djf": "1.470",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "219.827",
                             "son": "219.557",
                             "mam": "219.900",
                             "jja": "219.997",
-                            "djf": "219.860"
+                            "djf": "219.860",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "218.435",
                             "son": "218.260",
                             "mam": "218.841",
                             "jja": "218.175",
-                            "djf": "218.474"
+                            "djf": "218.474",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.582"
@@ -62,7 +67,8 @@
                             "son": "1.437",
                             "mam": "1.339",
                             "jja": "2.047",
-                            "djf": "1.606"
+                            "djf": "1.606",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.685"
@@ -75,14 +81,16 @@
                             "son": "0.618",
                             "mam": "0.820",
                             "jja": "0.933",
-                            "djf": "0.812"
+                            "djf": "0.812",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "0.972",
                             "son": "0.967",
                             "mam": "1.181",
                             "jja": "1.450",
-                            "djf": "1.016"
+                            "djf": "1.016",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.898"
@@ -95,7 +103,8 @@
                             "son": "0.772",
                             "mam": "0.832",
                             "jja": "1.141",
-                            "djf": "0.681"
+                            "djf": "0.681",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.658"
@@ -110,35 +119,40 @@
                             "son": "-1.698",
                             "mam": "-1.927",
                             "jja": "-2.172",
-                            "djf": "-1.958"
+                            "djf": "-1.958",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.767",
                             "son": "0.87",
                             "mam": "0.68",
                             "jja": "0.93",
-                            "djf": "0.83"
+                            "djf": "0.83",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.041",
                             "son": "1.996",
                             "mam": "2.030",
                             "jja": "2.543",
-                            "djf": "2.165"
+                            "djf": "2.165",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "218.991",
                             "son": "218.375",
                             "mam": "219.163",
                             "jja": "218.963",
-                            "djf": "219.469"
+                            "djf": "219.469",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "217.051",
                             "son": "216.677",
                             "mam": "217.236",
                             "jja": "216.792",
-                            "djf": "217.511"
+                            "djf": "217.511",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.712"
@@ -148,7 +162,8 @@
                             "son": "2.419",
                             "mam": "2.562",
                             "jja": "2.975",
-                            "djf": "2.621"
+                            "djf": "2.621",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.746"
@@ -161,14 +176,16 @@
                             "son": "1.722",
                             "mam": "1.689",
                             "jja": "2.033",
-                            "djf": "1.743"
+                            "djf": "1.743",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "1.983",
                             "son": "3.412",
                             "mam": "2.027",
                             "jja": "4.838",
-                            "djf": "3.127"
+                            "djf": "3.127",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.196"
@@ -181,7 +198,8 @@
                             "son": "2.758",
                             "mam": "2.162",
                             "jja": "3.597",
-                            "djf": "2.436"
+                            "djf": "2.436",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.996"
@@ -196,35 +214,40 @@
                             "son": "-2.644",
                             "mam": "-3.423",
                             "jja": "-4.048",
-                            "djf": "-1.700"
+                            "djf": "-1.700",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.786",
                             "son": "0.79",
                             "mam": "0.76",
                             "jja": "0.93",
-                            "djf": "0.79"
+                            "djf": "0.79",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.953",
                             "son": "2.644",
                             "mam": "3.440",
                             "jja": "4.048",
-                            "djf": "2.328"
+                            "djf": "2.328",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "219.134",
                             "son": "218.810",
                             "mam": "218.682",
                             "jja": "222.319",
-                            "djf": "216.692"
+                            "djf": "216.692",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "216.181",
                             "son": "216.166",
                             "mam": "215.258",
                             "jja": "218.271",
-                            "djf": "214.992"
+                            "djf": "214.992",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.849"
@@ -234,7 +257,8 @@
                             "son": "2.963",
                             "mam": "3.916",
                             "jja": "4.309",
-                            "djf": "2.715"
+                            "djf": "2.715",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.656"
@@ -247,14 +271,16 @@
                             "son": "1.338",
                             "mam": "1.901",
                             "jja": "1.476",
-                            "djf": "2.117"
+                            "djf": "2.117",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.127",
                             "son": "2.170",
                             "mam": "2.907",
                             "jja": "3.649",
-                            "djf": "3.449"
+                            "djf": "3.449",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.762"
@@ -267,7 +293,8 @@
                             "son": "1.909",
                             "mam": "2.238",
                             "jja": "2.830",
-                            "djf": "3.000"
+                            "djf": "3.000",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.434"
@@ -282,35 +309,40 @@
                             "son": "-1.555",
                             "mam": "-2.166",
                             "jja": "-0.995",
-                            "djf": "-3.359"
+                            "djf": "-3.359",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.602",
                             "son": "0.87",
                             "mam": "0.44",
                             "jja": "0.90",
-                            "djf": "0.89"
+                            "djf": "0.89",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.382",
                             "son": "2.710",
                             "mam": "2.314",
                             "jja": "2.448",
-                            "djf": "3.393"
+                            "djf": "3.393",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "217.175",
                             "son": "215.576",
                             "mam": "218.171",
                             "jja": "213.541",
-                            "djf": "221.465"
+                            "djf": "221.465",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "215.156",
                             "son": "214.021",
                             "mam": "216.005",
                             "jja": "212.546",
-                            "djf": "218.106"
+                            "djf": "218.106",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.793"
@@ -320,7 +352,8 @@
                             "son": "3.239",
                             "mam": "2.709",
                             "jja": "2.908",
-                            "djf": "3.867"
+                            "djf": "3.867",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.334"
@@ -333,14 +366,16 @@
                             "son": "2.842",
                             "mam": "1.627",
                             "jja": "2.732",
-                            "djf": "1.917"
+                            "djf": "1.917",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.142",
                             "son": "5.400",
                             "mam": "1.700",
                             "jja": "5.772",
-                            "djf": "3.624"
+                            "djf": "3.624",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.004"
@@ -353,7 +388,8 @@
                             "son": "3.643",
                             "mam": "1.312",
                             "jja": "4.137",
-                            "djf": "2.293"
+                            "djf": "2.293",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.021"

--- a/tests/pcmdi/multipleJsons/tas_GFDL-ESM2G-copy_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/multipleJsons/tas_GFDL-ESM2G-copy_2.5x2.5_regrid2_linear_metrics.json
@@ -48,14 +48,16 @@
                             "djf": "-0.682",
                             "mam": "-0.490",
                             "jja": "-0.526",
-                            "son": "-0.789"
+                            "son": "-0.789",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.990",
                             "djf": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -63,21 +65,24 @@
                             "djf": "1.993",
                             "mam": "1.835",
                             "jja": "1.534",
-                            "son": "1.698"
+                            "son": "1.698",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.563",
                             "djf": "285.822",
                             "mam": "287.535",
                             "jja": "289.271",
-                            "son": "287.607"
+                            "son": "287.607",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.937",
                             "djf": "285.141",
                             "mam": "287.046",
                             "jja": "288.745",
-                            "son": "286.818"
+                            "son": "286.818",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.394"
@@ -87,7 +92,8 @@
                             "djf": "2.766",
                             "mam": "2.467",
                             "jja": "1.997",
-                            "son": "2.181"
+                            "son": "2.181",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.466"
@@ -100,7 +106,8 @@
                             "djf": "2.681",
                             "mam": "2.418",
                             "jja": "1.927",
-                            "son": "2.033"
+                            "son": "2.033",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -108,7 +115,8 @@
                             "djf": "15.868",
                             "mam": "14.972",
                             "jja": "14.216",
-                            "son": "14.132"
+                            "son": "14.132",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.712"
@@ -121,7 +129,8 @@
                             "djf": "16.022",
                             "mam": "14.453",
                             "jja": "13.593",
-                            "son": "14.028"
+                            "son": "14.028",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.652"
@@ -136,14 +145,16 @@
                             "djf": "-2.539",
                             "mam": "-2.243",
                             "jja": "-1.578",
-                            "son": "-2.252"
+                            "son": "-2.252",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.983",
                             "djf": "0.97",
                             "mam": "0.97",
                             "jja": "0.98",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 311.615234375,
                         "mae_xy": {
@@ -151,21 +162,24 @@
                             "djf": "3.276",
                             "mam": "2.794",
                             "jja": "1.982",
-                            "son": "2.412"
+                            "son": "2.412",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.356",
                             "djf": "268.391",
                             "mam": "276.869",
                             "jja": "288.334",
-                            "son": "279.717"
+                            "son": "279.717",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.184",
                             "djf": "265.852",
                             "mam": "274.625",
                             "jja": "286.756",
-                            "son": "277.465"
+                            "son": "277.465",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.936"
@@ -175,7 +189,8 @@
                             "djf": "4.350",
                             "mam": "3.386",
                             "jja": "2.381",
-                            "son": "2.908"
+                            "son": "2.908",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.478"
@@ -188,7 +203,8 @@
                             "djf": "3.532",
                             "mam": "2.536",
                             "jja": "1.783",
-                            "son": "1.840"
+                            "son": "1.840",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -196,7 +212,8 @@
                             "djf": "15.100",
                             "mam": "11.127",
                             "jja": "8.083",
-                            "son": "11.143"
+                            "son": "11.143",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.970"
@@ -209,7 +226,8 @@
                             "djf": "15.124",
                             "mam": "10.980",
                             "jja": "8.371",
-                            "son": "11.403"
+                            "son": "11.403",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.612"
@@ -224,14 +242,16 @@
                             "djf": "1.917",
                             "mam": "2.012",
                             "jja": "1.063",
-                            "son": "0.819"
+                            "son": "0.819",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "djf": "0.99",
                             "mam": "1.00",
                             "jja": "0.99",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.42657470703125,
                         "mae_xy": {
@@ -239,21 +259,24 @@
                             "djf": "2.006",
                             "mam": "2.086",
                             "jja": "1.590",
-                            "son": "1.362"
+                            "son": "1.362",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.238",
                             "djf": "280.165",
                             "mam": "276.677",
                             "jja": "273.107",
-                            "son": "275.051"
+                            "son": "275.051",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.696",
                             "djf": "282.082",
                             "mam": "278.688",
                             "jja": "274.170",
-                            "son": "275.870"
+                            "son": "275.870",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.243"
@@ -263,7 +286,8 @@
                             "djf": "2.400",
                             "mam": "2.794",
                             "jja": "2.317",
-                            "son": "1.785"
+                            "son": "1.785",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.423"
@@ -276,7 +300,8 @@
                             "djf": "1.444",
                             "mam": "1.939",
                             "jja": "2.059",
-                            "son": "1.586"
+                            "son": "1.586",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -284,7 +309,8 @@
                             "djf": "12.162",
                             "mam": "17.007",
                             "jja": "17.286",
-                            "son": "14.974"
+                            "son": "14.974",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.536"
@@ -297,7 +323,8 @@
                             "djf": "11.554",
                             "mam": "15.952",
                             "jja": "16.782",
-                            "son": "14.824"
+                            "son": "14.824",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.895"
@@ -312,14 +339,16 @@
                             "djf": "-1.052",
                             "mam": "-0.864",
                             "jja": "-0.794",
-                            "son": "-0.862"
+                            "son": "-0.862",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.917",
                             "djf": "0.94",
                             "mam": "0.91",
                             "jja": "0.95",
-                            "son": "0.87"
+                            "son": "0.87",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -327,21 +356,24 @@
                             "djf": "1.345",
                             "mam": "1.229",
                             "jja": "1.283",
-                            "son": "1.509"
+                            "son": "1.509",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.828",
                             "djf": "297.367",
                             "mam": "298.298",
                             "jja": "297.821",
-                            "son": "297.831"
+                            "son": "297.831",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "djf": "296.315",
                             "mam": "297.434",
                             "jja": "297.027",
-                            "son": "296.969"
+                            "son": "296.969",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.113"
@@ -351,7 +383,8 @@
                             "djf": "1.721",
                             "mam": "1.593",
                             "jja": "1.569",
-                            "son": "1.921"
+                            "son": "1.921",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.783"
@@ -364,7 +397,8 @@
                             "djf": "1.362",
                             "mam": "1.339",
                             "jja": "1.353",
-                            "son": "1.717"
+                            "son": "1.717",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -372,7 +406,8 @@
                             "djf": "3.799",
                             "mam": "3.177",
                             "jja": "4.237",
-                            "son": "3.280"
+                            "son": "3.280",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.219"
@@ -385,7 +420,8 @@
                             "djf": "4.084",
                             "mam": "3.202",
                             "jja": "4.111",
-                            "son": "3.459"
+                            "son": "3.459",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.015"

--- a/tests/pcmdi/multipleJsons/tas_GFDL-ESM2G_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/multipleJsons/tas_GFDL-ESM2G_2.5x2.5_regrid2_linear_metrics.json
@@ -48,14 +48,16 @@
                             "djf": "-0.682",
                             "mam": "-0.490",
                             "jja": "-0.526",
-                            "son": "-0.789"
+                            "son": "-0.789",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.990",
                             "djf": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -63,21 +65,24 @@
                             "djf": "1.993",
                             "mam": "1.835",
                             "jja": "1.534",
-                            "son": "1.698"
+                            "son": "1.698",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.563",
                             "djf": "285.822",
                             "mam": "287.535",
                             "jja": "289.271",
-                            "son": "287.607"
+                            "son": "287.607",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.937",
                             "djf": "285.141",
                             "mam": "287.046",
                             "jja": "288.745",
-                            "son": "286.818"
+                            "son": "286.818",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.394"
@@ -87,7 +92,8 @@
                             "djf": "2.766",
                             "mam": "2.467",
                             "jja": "1.997",
-                            "son": "2.181"
+                            "son": "2.181",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.466"
@@ -100,7 +106,8 @@
                             "djf": "2.681",
                             "mam": "2.418",
                             "jja": "1.927",
-                            "son": "2.033"
+                            "son": "2.033",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -108,7 +115,8 @@
                             "djf": "15.868",
                             "mam": "14.972",
                             "jja": "14.216",
-                            "son": "14.132"
+                            "son": "14.132",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.712"
@@ -121,7 +129,8 @@
                             "djf": "16.022",
                             "mam": "14.453",
                             "jja": "13.593",
-                            "son": "14.028"
+                            "son": "14.028",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.652"
@@ -136,14 +145,16 @@
                             "djf": "-2.539",
                             "mam": "-2.243",
                             "jja": "-1.578",
-                            "son": "-2.252"
+                            "son": "-2.252",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.983",
                             "djf": "0.97",
                             "mam": "0.97",
                             "jja": "0.98",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 311.615234375,
                         "mae_xy": {
@@ -151,21 +162,24 @@
                             "djf": "3.276",
                             "mam": "2.794",
                             "jja": "1.982",
-                            "son": "2.412"
+                            "son": "2.412",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.356",
                             "djf": "268.391",
                             "mam": "276.869",
                             "jja": "288.334",
-                            "son": "279.717"
+                            "son": "279.717",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.184",
                             "djf": "265.852",
                             "mam": "274.625",
                             "jja": "286.756",
-                            "son": "277.465"
+                            "son": "277.465",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.936"
@@ -175,7 +189,8 @@
                             "djf": "4.350",
                             "mam": "3.386",
                             "jja": "2.381",
-                            "son": "2.908"
+                            "son": "2.908",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.478"
@@ -188,7 +203,8 @@
                             "djf": "3.532",
                             "mam": "2.536",
                             "jja": "1.783",
-                            "son": "1.840"
+                            "son": "1.840",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -196,7 +212,8 @@
                             "djf": "15.100",
                             "mam": "11.127",
                             "jja": "8.083",
-                            "son": "11.143"
+                            "son": "11.143",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.970"
@@ -209,7 +226,8 @@
                             "djf": "15.124",
                             "mam": "10.980",
                             "jja": "8.371",
-                            "son": "11.403"
+                            "son": "11.403",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.612"
@@ -224,14 +242,16 @@
                             "djf": "1.917",
                             "mam": "2.012",
                             "jja": "1.063",
-                            "son": "0.819"
+                            "son": "0.819",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "djf": "0.99",
                             "mam": "1.00",
                             "jja": "0.99",
-                            "son": "0.99"
+                            "son": "0.99",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 303.42657470703125,
                         "mae_xy": {
@@ -239,21 +259,24 @@
                             "djf": "2.006",
                             "mam": "2.086",
                             "jja": "1.590",
-                            "son": "1.362"
+                            "son": "1.362",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.238",
                             "djf": "280.165",
                             "mam": "276.677",
                             "jja": "273.107",
-                            "son": "275.051"
+                            "son": "275.051",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.696",
                             "djf": "282.082",
                             "mam": "278.688",
                             "jja": "274.170",
-                            "son": "275.870"
+                            "son": "275.870",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.243"
@@ -263,7 +286,8 @@
                             "djf": "2.400",
                             "mam": "2.794",
                             "jja": "2.317",
-                            "son": "1.785"
+                            "son": "1.785",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.423"
@@ -276,7 +300,8 @@
                             "djf": "1.444",
                             "mam": "1.939",
                             "jja": "2.059",
-                            "son": "1.586"
+                            "son": "1.586",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -284,7 +309,8 @@
                             "djf": "12.162",
                             "mam": "17.007",
                             "jja": "17.286",
-                            "son": "14.974"
+                            "son": "14.974",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.536"
@@ -297,7 +323,8 @@
                             "djf": "11.554",
                             "mam": "15.952",
                             "jja": "16.782",
-                            "son": "14.824"
+                            "son": "14.824",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.895"
@@ -312,14 +339,16 @@
                             "djf": "-1.052",
                             "mam": "-0.864",
                             "jja": "-0.794",
-                            "son": "-0.862"
+                            "son": "-0.862",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.917",
                             "djf": "0.94",
                             "mam": "0.91",
                             "jja": "0.95",
-                            "son": "0.87"
+                            "son": "0.87",
+                            "CalendarMonths": []
                         },
                         "custom_model_max": 312.8986511230469,
                         "mae_xy": {
@@ -327,21 +356,24 @@
                             "djf": "1.345",
                             "mam": "1.229",
                             "jja": "1.283",
-                            "son": "1.509"
+                            "son": "1.509",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.828",
                             "djf": "297.367",
                             "mam": "298.298",
                             "jja": "297.821",
-                            "son": "297.831"
+                            "son": "297.831",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "djf": "296.315",
                             "mam": "297.434",
                             "jja": "297.027",
-                            "son": "296.969"
+                            "son": "296.969",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.113"
@@ -351,7 +383,8 @@
                             "djf": "1.721",
                             "mam": "1.593",
                             "jja": "1.569",
-                            "son": "1.921"
+                            "son": "1.921",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.783"
@@ -364,7 +397,8 @@
                             "djf": "1.362",
                             "mam": "1.339",
                             "jja": "1.353",
-                            "son": "1.717"
+                            "son": "1.717",
+                            "CalendarMonths": []
                         },
                         "some_custom": 1.5,
                         "std-obs_xy": {
@@ -372,7 +406,8 @@
                             "djf": "3.799",
                             "mam": "3.177",
                             "jja": "4.237",
-                            "son": "3.280"
+                            "son": "3.280",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.219"
@@ -385,7 +420,8 @@
                             "djf": "4.084",
                             "mam": "3.202",
                             "jja": "4.111",
-                            "son": "3.459"
+                            "son": "3.459",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.015"

--- a/tests/pcmdi/nosftlfTest/tas_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/nosftlfTest/tas_2.5x2.5_esmf_linear_metrics.json
@@ -24,35 +24,40 @@
                             "son": "-0.870",
                             "mam": "-0.872",
                             "jja": "-0.802",
-                            "djf": "-1.060"
+                            "djf": "-1.060",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.912",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.94",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.260",
                             "son": "1.538",
                             "mam": "1.263",
                             "jja": "1.317",
-                            "djf": "1.377"
+                            "djf": "1.377",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.836",
                             "son": "297.839",
                             "mam": "298.306",
                             "jja": "297.828",
-                            "djf": "297.375"
+                            "djf": "297.375",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.026",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.169"
@@ -62,7 +67,8 @@
                             "son": "1.958",
                             "mam": "1.645",
                             "jja": "1.614",
-                            "djf": "1.767"
+                            "djf": "1.767",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.828"
@@ -75,14 +81,16 @@
                             "son": "1.755",
                             "mam": "1.395",
                             "jja": "1.401",
-                            "djf": "1.414"
+                            "djf": "1.414",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "3.033",
                             "son": "3.322",
                             "mam": "3.227",
                             "jja": "4.268",
-                            "djf": "3.842"
+                            "djf": "3.842",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.280"
@@ -95,7 +103,8 @@
                             "son": "3.473",
                             "mam": "3.213",
                             "jja": "4.120",
-                            "djf": "4.093"
+                            "djf": "4.093",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.026"
@@ -110,35 +119,40 @@
                             "son": "-0.787",
                             "mam": "-0.489",
                             "jja": "-0.526",
-                            "djf": "-0.680"
+                            "djf": "-0.680",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.989",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.669",
                             "son": "1.726",
                             "mam": "1.861",
                             "jja": "1.568",
-                            "djf": "2.025"
+                            "djf": "2.025",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.558",
                             "son": "287.602",
                             "mam": "287.530",
                             "jja": "289.266",
-                            "djf": "285.818"
+                            "djf": "285.818",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.933",
                             "son": "286.815",
                             "mam": "287.041",
                             "jja": "288.741",
-                            "djf": "285.138"
+                            "djf": "285.138",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.454"
@@ -148,7 +162,8 @@
                             "son": "2.219",
                             "mam": "2.505",
                             "jja": "2.051",
-                            "djf": "2.805"
+                            "djf": "2.805",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.508"
@@ -161,14 +176,16 @@
                             "son": "2.075",
                             "mam": "2.457",
                             "jja": "1.983",
-                            "djf": "2.721"
+                            "djf": "2.721",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "14.108",
                             "son": "14.163",
                             "mam": "15.003",
                             "jja": "14.244",
-                            "djf": "15.898"
+                            "djf": "15.898",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.769"
@@ -181,7 +198,8 @@
                             "son": "14.042",
                             "mam": "14.468",
                             "jja": "13.608",
-                            "djf": "16.032"
+                            "djf": "16.032",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.670"
@@ -196,35 +214,40 @@
                             "son": "-2.236",
                             "mam": "-2.226",
                             "jja": "-1.562",
-                            "djf": "-2.525"
+                            "djf": "-2.525",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.982",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.97",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.471",
                             "son": "2.441",
                             "mam": "2.821",
                             "jja": "2.026",
-                            "djf": "3.324"
+                            "djf": "3.324",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.335",
                             "son": "279.695",
                             "mam": "276.844",
                             "jja": "288.315",
-                            "djf": "268.370"
+                            "djf": "268.370",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.179",
                             "son": "277.459",
                             "mam": "274.619",
                             "jja": "286.752",
-                            "djf": "265.845"
+                            "djf": "265.845",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "2.012"
@@ -234,7 +257,8 @@
                             "son": "2.950",
                             "mam": "3.427",
                             "jja": "2.464",
-                            "djf": "4.394"
+                            "djf": "4.394",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.527"
@@ -247,14 +271,16 @@
                             "son": "1.924",
                             "mam": "2.606",
                             "jja": "1.906",
-                            "djf": "3.596"
+                            "djf": "3.596",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "10.873",
                             "son": "11.178",
                             "mam": "11.155",
                             "jja": "8.120",
-                            "djf": "15.134"
+                            "djf": "15.134",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "5.044"
@@ -267,7 +293,8 @@
                             "son": "11.413",
                             "mam": "10.992",
                             "jja": "8.384",
-                            "djf": "15.136"
+                            "djf": "15.136",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.633"
@@ -282,35 +309,40 @@
                             "son": "0.826",
                             "mam": "2.015",
                             "jja": "1.064",
-                            "djf": "1.926"
+                            "djf": "1.926",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.684",
                             "son": "1.387",
                             "mam": "2.096",
                             "jja": "1.612",
-                            "djf": "2.023"
+                            "djf": "2.023",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.225",
                             "son": "275.036",
                             "mam": "276.663",
                             "jja": "273.095",
-                            "djf": "280.151"
+                            "djf": "280.151",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.687",
                             "son": "275.862",
                             "mam": "278.678",
                             "jja": "274.159",
-                            "djf": "282.077"
+                            "djf": "282.077",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.293"
@@ -320,7 +352,8 @@
                             "son": "1.826",
                             "mam": "2.818",
                             "jja": "2.356",
-                            "djf": "2.432"
+                            "djf": "2.432",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.456"
@@ -333,14 +366,16 @@
                             "son": "1.629",
                             "mam": "1.970",
                             "jja": "2.102",
-                            "djf": "1.485"
+                            "djf": "1.485",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "15.321",
                             "son": "15.010",
                             "mam": "17.048",
                             "jja": "17.324",
-                            "djf": "12.198"
+                            "djf": "12.198",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.580"
@@ -353,7 +388,8 @@
                             "son": "14.852",
                             "mam": "15.984",
                             "jja": "16.812",
-                            "djf": "11.581"
+                            "djf": "11.581",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.921"

--- a/tests/pcmdi/obsByNameTest/tas_2.5x2.5_regrid2_linear_metrics.json
+++ b/tests/pcmdi/obsByNameTest/tas_2.5x2.5_regrid2_linear_metrics.json
@@ -37,35 +37,40 @@
                             "son": "-0.862",
                             "mam": "-0.864",
                             "jja": "-0.794",
-                            "djf": "-1.052"
+                            "djf": "-1.052",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.917",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.95",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.228",
                             "son": "1.509",
                             "mam": "1.229",
                             "jja": "1.283",
-                            "djf": "1.345"
+                            "djf": "1.345",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.828",
                             "son": "297.831",
                             "mam": "298.298",
                             "jja": "297.821",
-                            "djf": "297.367"
+                            "djf": "297.367",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.027",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.113"
@@ -75,7 +80,8 @@
                             "son": "1.921",
                             "mam": "1.593",
                             "jja": "1.569",
-                            "djf": "1.721"
+                            "djf": "1.721",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.783"
@@ -88,14 +94,16 @@
                             "son": "1.717",
                             "mam": "1.339",
                             "jja": "1.353",
-                            "djf": "1.362"
+                            "djf": "1.362",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.989",
                             "son": "3.280",
                             "mam": "3.177",
                             "jja": "4.237",
-                            "djf": "3.799"
+                            "djf": "3.799",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.219"
@@ -108,7 +116,8 @@
                             "son": "3.459",
                             "mam": "3.202",
                             "jja": "4.111",
-                            "djf": "4.084"
+                            "djf": "4.084",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.015"
@@ -123,35 +132,40 @@
                             "son": "-1.032",
                             "mam": "-0.980",
                             "jja": "-1.086",
-                            "djf": "-0.735"
+                            "djf": "-0.735",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.993",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.882",
                             "son": "2.173",
                             "mam": "2.321",
                             "jja": "2.075",
-                            "djf": "2.123"
+                            "djf": "2.123",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "282.539",
                             "son": "282.965",
                             "mam": "282.315",
                             "jja": "287.861",
-                            "djf": "276.961"
+                            "djf": "276.961",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "281.569",
                             "son": "281.908",
                             "mam": "281.384",
                             "jja": "286.736",
-                            "djf": "276.237"
+                            "djf": "276.237",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.807"
@@ -161,7 +175,8 @@
                             "son": "2.722",
                             "mam": "2.950",
                             "jja": "2.597",
-                            "djf": "2.709"
+                            "djf": "2.709",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.899"
@@ -174,14 +189,16 @@
                             "son": "2.518",
                             "mam": "2.782",
                             "jja": "2.359",
-                            "djf": "2.607"
+                            "djf": "2.607",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "18.272",
                             "son": "18.466",
                             "mam": "19.788",
                             "jja": "19.450",
-                            "djf": "20.037"
+                            "djf": "20.037",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.780"
@@ -194,7 +211,8 @@
                             "son": "18.806",
                             "mam": "19.052",
                             "jja": "19.448",
-                            "djf": "19.421"
+                            "djf": "19.421",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "5.026"
@@ -209,35 +227,40 @@
                             "son": "-0.789",
                             "mam": "-0.490",
                             "jja": "-0.526",
-                            "djf": "-0.682"
+                            "djf": "-0.682",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.990",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.640",
                             "son": "1.698",
                             "mam": "1.835",
                             "jja": "1.534",
-                            "djf": "1.993"
+                            "djf": "1.993",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.563",
                             "son": "287.607",
                             "mam": "287.535",
                             "jja": "289.271",
-                            "djf": "285.822"
+                            "djf": "285.822",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.937",
                             "son": "286.818",
                             "mam": "287.046",
                             "jja": "288.745",
-                            "djf": "285.141"
+                            "djf": "285.141",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.394"
@@ -247,7 +270,8 @@
                             "son": "2.181",
                             "mam": "2.467",
                             "jja": "1.997",
-                            "djf": "2.766"
+                            "djf": "2.766",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.466"
@@ -260,14 +284,16 @@
                             "son": "2.033",
                             "mam": "2.418",
                             "jja": "1.927",
-                            "djf": "2.681"
+                            "djf": "2.681",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "14.079",
                             "son": "14.132",
                             "mam": "14.972",
                             "jja": "14.216",
-                            "djf": "15.868"
+                            "djf": "15.868",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.712"
@@ -280,7 +306,8 @@
                             "son": "14.028",
                             "mam": "14.453",
                             "jja": "13.593",
-                            "djf": "16.022"
+                            "djf": "16.022",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.652"
@@ -295,35 +322,40 @@
                             "son": "-2.252",
                             "mam": "-2.243",
                             "jja": "-1.578",
-                            "djf": "-2.539"
+                            "djf": "-2.539",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.983",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.98",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.440",
                             "son": "2.412",
                             "mam": "2.794",
                             "jja": "1.982",
-                            "djf": "3.276"
+                            "djf": "3.276",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.356",
                             "son": "279.717",
                             "mam": "276.869",
                             "jja": "288.334",
-                            "djf": "268.391"
+                            "djf": "268.391",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.184",
                             "son": "277.465",
                             "mam": "274.625",
                             "jja": "286.756",
-                            "djf": "265.852"
+                            "djf": "265.852",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.936"
@@ -333,7 +365,8 @@
                             "son": "2.908",
                             "mam": "3.386",
                             "jja": "2.381",
-                            "djf": "4.350"
+                            "djf": "4.350",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.478"
@@ -346,14 +379,16 @@
                             "son": "1.840",
                             "mam": "2.536",
                             "jja": "1.783",
-                            "djf": "3.532"
+                            "djf": "3.532",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "10.844",
                             "son": "11.143",
                             "mam": "11.127",
                             "jja": "8.083",
-                            "djf": "15.100"
+                            "djf": "15.100",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.970"
@@ -366,7 +401,8 @@
                             "son": "11.403",
                             "mam": "10.980",
                             "jja": "8.371",
-                            "djf": "15.124"
+                            "djf": "15.124",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.612"
@@ -381,35 +417,40 @@
                             "son": "0.819",
                             "mam": "2.012",
                             "jja": "1.063",
-                            "djf": "1.917"
+                            "djf": "1.917",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "1.00",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.667",
                             "son": "1.362",
                             "mam": "2.086",
                             "jja": "1.590",
-                            "djf": "2.006"
+                            "djf": "2.006",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.238",
                             "son": "275.051",
                             "mam": "276.677",
                             "jja": "273.107",
-                            "djf": "280.165"
+                            "djf": "280.165",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.696",
                             "son": "275.870",
                             "mam": "278.688",
                             "jja": "274.170",
-                            "djf": "282.082"
+                            "djf": "282.082",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.243"
@@ -419,7 +460,8 @@
                             "son": "1.785",
                             "mam": "2.794",
                             "jja": "2.317",
-                            "djf": "2.400"
+                            "djf": "2.400",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.423"
@@ -432,14 +474,16 @@
                             "son": "1.586",
                             "mam": "1.939",
                             "jja": "2.059",
-                            "djf": "1.444"
+                            "djf": "1.444",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "15.284",
                             "son": "14.974",
                             "mam": "17.007",
                             "jja": "17.286",
-                            "djf": "12.162"
+                            "djf": "12.162",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.536"
@@ -452,7 +496,8 @@
                             "son": "14.824",
                             "mam": "15.952",
                             "jja": "16.782",
-                            "djf": "11.554"
+                            "djf": "11.554",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.895"

--- a/tests/pcmdi/salinityTest/sos_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/salinityTest/sos_2.5x2.5_esmf_linear_metrics.json
@@ -29,35 +29,40 @@
                             "son": "-0.191",
                             "mam": "-0.107",
                             "jja": "-0.175",
-                            "djf": "-0.180"
+                            "djf": "-0.180",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.851",
                             "son": "0.84",
                             "mam": "0.79",
                             "jja": "0.80",
-                            "djf": "0.86"
+                            "djf": "0.86",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.421",
                             "son": "0.462",
                             "mam": "0.459",
                             "jja": "0.477",
-                            "djf": "0.417"
+                            "djf": "0.417",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "35.141",
                             "son": "35.148",
                             "mam": "35.097",
                             "jja": "35.186",
-                            "djf": "35.170"
+                            "djf": "35.170",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.938",
                             "son": "34.912",
                             "mam": "34.939",
                             "jja": "34.953",
-                            "djf": "34.948"
+                            "djf": "34.948",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.431"
@@ -67,7 +72,8 @@
                             "son": "0.576",
                             "mam": "0.599",
                             "jja": "0.605",
-                            "djf": "0.536"
+                            "djf": "0.536",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.611"
@@ -80,14 +86,16 @@
                             "son": "0.543",
                             "mam": "0.590",
                             "jja": "0.579",
-                            "djf": "0.505"
+                            "djf": "0.505",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "0.951",
                             "son": "0.991",
                             "mam": "0.937",
                             "jja": "0.948",
-                            "djf": "0.971"
+                            "djf": "0.971",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.827"
@@ -100,7 +108,8 @@
                             "son": "1.003",
                             "mam": "0.987",
                             "jja": "0.956",
-                            "djf": "0.973"
+                            "djf": "0.973",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.860"
@@ -115,35 +124,40 @@
                             "son": "-0.192",
                             "mam": "0.021",
                             "jja": "-0.124",
-                            "djf": "-0.087"
+                            "djf": "-0.087",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.778",
                             "son": "0.85",
                             "mam": "0.83",
                             "jja": "0.82",
-                            "djf": "0.84"
+                            "djf": "0.84",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.529",
                             "son": "0.455",
                             "mam": "0.481",
                             "jja": "0.475",
-                            "djf": "0.435"
+                            "djf": "0.435",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "34.635",
                             "son": "34.914",
                             "mam": "34.718",
                             "jja": "34.851",
-                            "djf": "34.808"
+                            "djf": "34.808",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.525",
                             "son": "34.507",
                             "mam": "34.544",
                             "jja": "34.515",
-                            "djf": "34.537"
+                            "djf": "34.537",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.769"
@@ -153,7 +167,8 @@
                             "son": "0.583",
                             "mam": "0.634",
                             "jja": "0.649",
-                            "djf": "0.609"
+                            "djf": "0.609",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.762"
@@ -166,14 +181,16 @@
                             "son": "0.551",
                             "mam": "0.634",
                             "jja": "0.637",
-                            "djf": "0.603"
+                            "djf": "0.603",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "1.550",
                             "son": "1.045",
                             "mam": "1.121",
                             "jja": "1.105",
-                            "djf": "1.118"
+                            "djf": "1.118",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.024"
@@ -186,7 +203,8 @@
                             "son": "1.653",
                             "mam": "1.589",
                             "jja": "1.664",
-                            "djf": "1.596"
+                            "djf": "1.596",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.359"
@@ -201,35 +219,40 @@
                             "son": "0.050",
                             "mam": "0.092",
                             "jja": "-0.146",
-                            "djf": "0.303"
+                            "djf": "0.303",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.744",
                             "son": "0.91",
                             "mam": "0.92",
                             "jja": "0.87",
-                            "djf": "0.86"
+                            "djf": "0.86",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.872",
                             "son": "0.459",
                             "mam": "0.406",
                             "jja": "0.491",
-                            "djf": "0.566"
+                            "djf": "0.566",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "33.638",
                             "son": "34.315",
                             "mam": "34.447",
                             "jja": "34.374",
-                            "djf": "34.236"
+                            "djf": "34.236",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "33.559",
                             "son": "33.450",
                             "mam": "33.718",
                             "jja": "33.404",
-                            "djf": "33.669"
+                            "djf": "33.669",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.664"
@@ -239,7 +262,8 @@
                             "son": "0.672",
                             "mam": "0.569",
                             "jja": "0.883",
-                            "djf": "0.869"
+                            "djf": "0.869",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.225"
@@ -252,14 +276,16 @@
                             "son": "0.670",
                             "mam": "0.561",
                             "jja": "0.871",
-                            "djf": "0.815"
+                            "djf": "0.815",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.875",
                             "son": "1.457",
                             "mam": "1.384",
                             "jja": "1.526",
-                            "djf": "1.568"
+                            "djf": "1.568",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.018"
@@ -272,7 +298,8 @@
                             "son": "3.365",
                             "mam": "3.219",
                             "jja": "3.401",
-                            "djf": "3.243"
+                            "djf": "3.243",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.953"
@@ -287,35 +314,40 @@
                             "son": "-0.306",
                             "mam": "0.223",
                             "jja": "-0.012",
-                            "djf": "-0.083"
+                            "djf": "-0.083",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.671",
                             "son": "0.79",
                             "mam": "0.79",
                             "jja": "0.78",
-                            "djf": "0.78"
+                            "djf": "0.78",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.559",
                             "son": "0.440",
                             "mam": "0.551",
                             "jja": "0.463",
-                            "djf": "0.416"
+                            "djf": "0.416",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "34.228",
                             "son": "34.738",
                             "mam": "34.142",
                             "jja": "34.427",
-                            "djf": "34.421"
+                            "djf": "34.421",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.335",
                             "son": "34.378",
                             "mam": "34.307",
                             "jja": "34.356",
-                            "djf": "34.296"
+                            "djf": "34.296",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.561"
@@ -325,7 +357,8 @@
                             "son": "0.552",
                             "mam": "0.716",
                             "jja": "0.598",
-                            "djf": "0.602"
+                            "djf": "0.602",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.742"
@@ -338,14 +371,16 @@
                             "son": "0.460",
                             "mam": "0.681",
                             "jja": "0.597",
-                            "djf": "0.596"
+                            "djf": "0.596",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "1.140",
                             "son": "0.724",
                             "mam": "1.020",
                             "jja": "0.898",
-                            "djf": "0.892"
+                            "djf": "0.892",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.577"
@@ -358,7 +393,8 @@
                             "son": "0.441",
                             "mam": "0.541",
                             "jja": "0.475",
-                            "djf": "0.520"
+                            "djf": "0.520",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.249"

--- a/tests/pcmdi/salinityTest/sos_2.5x2.5_esmf_linear_metrics.json.mac
+++ b/tests/pcmdi/salinityTest/sos_2.5x2.5_esmf_linear_metrics.json.mac
@@ -29,35 +29,40 @@
                             "son": "-0.190",
                             "mam": "-0.105",
                             "jja": "-0.173",
-                            "djf": "-0.178"
+                            "djf": "-0.178",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.851",
                             "son": "0.84",
                             "mam": "0.79",
                             "jja": "0.80",
-                            "djf": "0.85"
+                            "djf": "0.85",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.421",
                             "son": "0.462",
                             "mam": "0.460",
                             "jja": "0.478",
-                            "djf": "0.417"
+                            "djf": "0.417",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "35.141",
                             "son": "35.146",
                             "mam": "35.094",
                             "jja": "35.182",
-                            "djf": "35.168"
+                            "djf": "35.168",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.936",
                             "son": "34.909",
                             "mam": "34.937",
                             "jja": "34.951",
-                            "djf": "34.946"
+                            "djf": "34.946",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.432"
@@ -67,7 +72,8 @@
                             "son": "0.577",
                             "mam": "0.600",
                             "jja": "0.606",
-                            "djf": "0.538"
+                            "djf": "0.538",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.612"
@@ -80,14 +86,16 @@
                             "son": "0.545",
                             "mam": "0.591",
                             "jja": "0.581",
-                            "djf": "0.508"
+                            "djf": "0.508",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "0.953",
                             "son": "0.998",
                             "mam": "0.940",
                             "jja": "0.954",
-                            "djf": "0.975"
+                            "djf": "0.975",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.829"
@@ -100,7 +108,8 @@
                             "son": "0.997",
                             "mam": "0.981",
                             "jja": "0.950",
-                            "djf": "0.967"
+                            "djf": "0.967",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.854"
@@ -115,35 +124,40 @@
                             "son": "-0.192",
                             "mam": "0.021",
                             "jja": "-0.123",
-                            "djf": "-0.086"
+                            "djf": "-0.086",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.778",
                             "son": "0.85",
                             "mam": "0.82",
                             "jja": "0.82",
-                            "djf": "0.84"
+                            "djf": "0.84",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.528",
                             "son": "0.455",
                             "mam": "0.481",
                             "jja": "0.475",
-                            "djf": "0.436"
+                            "djf": "0.436",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "34.636",
                             "son": "34.913",
                             "mam": "34.717",
                             "jja": "34.851",
-                            "djf": "34.806"
+                            "djf": "34.806",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.523",
                             "son": "34.505",
                             "mam": "34.542",
                             "jja": "34.513",
-                            "djf": "34.535"
+                            "djf": "34.535",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.767"
@@ -153,7 +167,8 @@
                             "son": "0.584",
                             "mam": "0.636",
                             "jja": "0.650",
-                            "djf": "0.612"
+                            "djf": "0.612",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.763"
@@ -166,14 +181,16 @@
                             "son": "0.552",
                             "mam": "0.636",
                             "jja": "0.638",
-                            "djf": "0.606"
+                            "djf": "0.606",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "1.549",
                             "son": "1.048",
                             "mam": "1.121",
                             "jja": "1.106",
-                            "djf": "1.121"
+                            "djf": "1.121",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "1.023"
@@ -186,7 +203,8 @@
                             "son": "1.650",
                             "mam": "1.586",
                             "jja": "1.662",
-                            "djf": "1.593"
+                            "djf": "1.593",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "1.356"
@@ -201,35 +219,40 @@
                             "son": "0.048",
                             "mam": "0.087",
                             "jja": "-0.149",
-                            "djf": "0.302"
+                            "djf": "0.302",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.742",
                             "son": "0.91",
                             "mam": "0.92",
                             "jja": "0.87",
-                            "djf": "0.85"
+                            "djf": "0.85",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.874",
                             "son": "0.459",
                             "mam": "0.411",
                             "jja": "0.490",
-                            "djf": "0.572"
+                            "djf": "0.572",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "33.637",
                             "son": "34.316",
                             "mam": "34.446",
                             "jja": "34.376",
-                            "djf": "34.230"
+                            "djf": "34.230",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "33.554",
                             "son": "33.445",
                             "mam": "33.713",
                             "jja": "33.399",
-                            "djf": "33.664"
+                            "djf": "33.664",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.668"
@@ -239,7 +262,8 @@
                             "son": "0.674",
                             "mam": "0.587",
                             "jja": "0.884",
-                            "djf": "0.882"
+                            "djf": "0.882",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.230"
@@ -252,14 +276,16 @@
                             "son": "0.672",
                             "mam": "0.580",
                             "jja": "0.872",
-                            "djf": "0.829"
+                            "djf": "0.829",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "2.877",
                             "son": "1.455",
                             "mam": "1.383",
                             "jja": "1.524",
-                            "djf": "1.573"
+                            "djf": "1.573",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.020"
@@ -272,7 +298,8 @@
                             "son": "3.362",
                             "mam": "3.217",
                             "jja": "3.399",
-                            "djf": "3.241"
+                            "djf": "3.241",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.952"
@@ -287,35 +314,40 @@
                             "son": "-0.306",
                             "mam": "0.223",
                             "jja": "-0.013",
-                            "djf": "-0.083"
+                            "djf": "-0.083",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.678",
                             "son": "0.79",
                             "mam": "0.79",
                             "jja": "0.78",
-                            "djf": "0.78"
+                            "djf": "0.78",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "0.555",
                             "son": "0.440",
                             "mam": "0.550",
                             "jja": "0.462",
-                            "djf": "0.415"
+                            "djf": "0.415",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "34.232",
                             "son": "34.739",
                             "mam": "34.144",
                             "jja": "34.431",
-                            "djf": "34.422"
+                            "djf": "34.422",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "34.334",
                             "son": "34.378",
                             "mam": "34.306",
                             "jja": "34.356",
-                            "djf": "34.295"
+                            "djf": "34.295",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "0.547"
@@ -325,7 +357,8 @@
                             "son": "0.552",
                             "mam": "0.716",
                             "jja": "0.596",
-                            "djf": "0.601"
+                            "djf": "0.601",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "0.739"
@@ -338,14 +371,16 @@
                             "son": "0.460",
                             "mam": "0.680",
                             "jja": "0.596",
-                            "djf": "0.596"
+                            "djf": "0.596",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "1.130",
                             "son": "0.725",
                             "mam": "1.020",
                             "jja": "0.897",
-                            "djf": "0.892"
+                            "djf": "0.892",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "0.564"
@@ -358,7 +393,8 @@
                             "son": "0.441",
                             "mam": "0.540",
                             "jja": "0.475",
-                            "djf": "0.519"
+                            "djf": "0.519",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "0.249"

--- a/tests/pcmdi/unitsTest/tas_2.5x2.5_esmf_linear_metrics.json
+++ b/tests/pcmdi/unitsTest/tas_2.5x2.5_esmf_linear_metrics.json
@@ -24,35 +24,40 @@
                             "son": "-0.870",
                             "mam": "-0.872",
                             "jja": "-0.802",
-                            "djf": "-1.060"
+                            "djf": "-1.060",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.912",
                             "son": "0.87",
                             "mam": "0.91",
                             "jja": "0.94",
-                            "djf": "0.94"
+                            "djf": "0.94",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.260",
                             "son": "1.538",
                             "mam": "1.263",
                             "jja": "1.317",
-                            "djf": "1.377"
+                            "djf": "1.377",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "297.836",
                             "son": "297.839",
                             "mam": "298.306",
                             "jja": "297.828",
-                            "djf": "297.375"
+                            "djf": "297.375",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "296.934",
                             "son": "296.969",
                             "mam": "297.434",
                             "jja": "297.026",
-                            "djf": "296.315"
+                            "djf": "296.315",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.169"
@@ -62,7 +67,8 @@
                             "son": "1.958",
                             "mam": "1.645",
                             "jja": "1.614",
-                            "djf": "1.767"
+                            "djf": "1.767",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "1.828"
@@ -75,14 +81,16 @@
                             "son": "1.755",
                             "mam": "1.395",
                             "jja": "1.401",
-                            "djf": "1.414"
+                            "djf": "1.414",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "3.033",
                             "son": "3.322",
                             "mam": "3.227",
                             "jja": "4.268",
-                            "djf": "3.842"
+                            "djf": "3.842",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "2.280"
@@ -95,7 +103,8 @@
                             "son": "3.473",
                             "mam": "3.213",
                             "jja": "4.120",
-                            "djf": "4.093"
+                            "djf": "4.093",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "2.026"
@@ -110,35 +119,40 @@
                             "son": "-0.787",
                             "mam": "-0.489",
                             "jja": "-0.526",
-                            "djf": "-0.680"
+                            "djf": "-0.680",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.989",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.669",
                             "son": "1.726",
                             "mam": "1.861",
                             "jja": "1.568",
-                            "djf": "2.025"
+                            "djf": "2.025",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "287.558",
                             "son": "287.602",
                             "mam": "287.530",
                             "jja": "289.266",
-                            "djf": "285.818"
+                            "djf": "285.818",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "286.933",
                             "son": "286.815",
                             "mam": "287.041",
                             "jja": "288.741",
-                            "djf": "285.138"
+                            "djf": "285.138",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.454"
@@ -148,7 +162,8 @@
                             "son": "2.219",
                             "mam": "2.505",
                             "jja": "2.051",
-                            "djf": "2.805"
+                            "djf": "2.805",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.508"
@@ -161,14 +176,16 @@
                             "son": "2.075",
                             "mam": "2.457",
                             "jja": "1.983",
-                            "djf": "2.721"
+                            "djf": "2.721",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "14.108",
                             "son": "14.163",
                             "mam": "15.003",
                             "jja": "14.244",
-                            "djf": "15.898"
+                            "djf": "15.898",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "3.769"
@@ -181,7 +198,8 @@
                             "son": "14.042",
                             "mam": "14.468",
                             "jja": "13.608",
-                            "djf": "16.032"
+                            "djf": "16.032",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "3.670"
@@ -196,35 +214,40 @@
                             "son": "-2.236",
                             "mam": "-2.226",
                             "jja": "-1.562",
-                            "djf": "-2.525"
+                            "djf": "-2.525",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.982",
                             "son": "0.99",
                             "mam": "0.97",
                             "jja": "0.97",
-                            "djf": "0.97"
+                            "djf": "0.97",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "2.471",
                             "son": "2.441",
                             "mam": "2.821",
                             "jja": "2.026",
-                            "djf": "3.324"
+                            "djf": "3.324",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "278.335",
                             "son": "279.695",
                             "mam": "276.844",
                             "jja": "288.315",
-                            "djf": "268.370"
+                            "djf": "268.370",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "276.179",
                             "son": "277.459",
                             "mam": "274.619",
                             "jja": "286.752",
-                            "djf": "265.845"
+                            "djf": "265.845",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "2.012"
@@ -234,7 +257,8 @@
                             "son": "2.950",
                             "mam": "3.427",
                             "jja": "2.464",
-                            "djf": "4.394"
+                            "djf": "4.394",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "3.527"
@@ -247,14 +271,16 @@
                             "son": "1.924",
                             "mam": "2.606",
                             "jja": "1.906",
-                            "djf": "3.596"
+                            "djf": "3.596",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "10.873",
                             "son": "11.178",
                             "mam": "11.155",
                             "jja": "8.120",
-                            "djf": "15.134"
+                            "djf": "15.134",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "5.044"
@@ -267,7 +293,8 @@
                             "son": "11.413",
                             "mam": "10.992",
                             "jja": "8.384",
-                            "djf": "15.136"
+                            "djf": "15.136",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.633"
@@ -282,35 +309,40 @@
                             "son": "0.826",
                             "mam": "2.015",
                             "jja": "1.064",
-                            "djf": "1.926"
+                            "djf": "1.926",
+                            "CalendarMonths": []
                         },
                         "cor_xy": {
                             "ann": "0.995",
                             "son": "0.99",
                             "mam": "0.99",
                             "jja": "0.99",
-                            "djf": "0.99"
+                            "djf": "0.99",
+                            "CalendarMonths": []
                         },
                         "mae_xy": {
                             "ann": "1.684",
                             "son": "1.387",
                             "mam": "2.096",
                             "jja": "1.612",
-                            "djf": "2.023"
+                            "djf": "2.023",
+                            "CalendarMonths": []
                         },
                         "mean-obs_xy": {
                             "ann": "276.225",
                             "son": "275.036",
                             "mam": "276.663",
                             "jja": "273.095",
-                            "djf": "280.151"
+                            "djf": "280.151",
+                            "CalendarMonths": []
                         },
                         "mean_xy": {
                             "ann": "277.687",
                             "son": "275.862",
                             "mam": "278.678",
                             "jja": "274.159",
-                            "djf": "282.077"
+                            "djf": "282.077",
+                            "CalendarMonths": []
                         },
                         "rms_devzm": {
                             "ann": "1.293"
@@ -320,7 +352,8 @@
                             "son": "1.826",
                             "mam": "2.818",
                             "jja": "2.356",
-                            "djf": "2.432"
+                            "djf": "2.432",
+                            "CalendarMonths": []
                         },
                         "rms_xyt": {
                             "ann": "2.456"
@@ -333,14 +366,16 @@
                             "son": "1.629",
                             "mam": "1.970",
                             "jja": "2.102",
-                            "djf": "1.485"
+                            "djf": "1.485",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy": {
                             "ann": "15.321",
                             "son": "15.010",
                             "mam": "17.048",
                             "jja": "17.324",
-                            "djf": "12.198"
+                            "djf": "12.198",
+                            "CalendarMonths": []
                         },
                         "std-obs_xy_devzm": {
                             "ann": "4.580"
@@ -353,7 +388,8 @@
                             "son": "14.852",
                             "mam": "15.984",
                             "jja": "16.812",
-                            "djf": "11.581"
+                            "djf": "11.581",
+                            "CalendarMonths": []
                         },
                         "std_xy_devzm": {
                             "ann": "4.921"


### PR DESCRIPTION
I manually added the "CalendarMonths" key with an empty list to the reference JSONs used for testing the mean climate metrics. We currently do not check what is in the CalendarMonths list, so the empty list is sufficient to help the tests pass.

Testing: These files passed all the tests locally.

I pulled in branch 758_ljw_circleci_test_pause to reactivate the CircleCI tests in the CircleCI configuration file.