### PR TITLE
Turn output directory into variable

### DIFF
--- a/doc/jupyter/Demo/Demo_6_ENSO.ipynb
+++ b/doc/jupyter/Demo/Demo_6_ENSO.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f02518f6",
    "metadata": {},
    "source": [
     "# ENSO"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bb7a1ac",
    "metadata": {},
    "source": [
     "This notebook provides an overview of running the ENSO metrics. More information can be found in the [README]( ). Example parameter files are located in the [PMP sample setups]( ). \n",
@@ -30,7 +28,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a6383bf",
    "metadata": {},
    "source": [
     "## Download demo data"
@@ -38,7 +35,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdc4b9e2",
    "metadata": {},
    "source": [
     "The ENSO metric requires a different set of sample data than the rest of the PMP metrics. This section of the notebook will download that data to your chosen location and generate a basic parameter file."
@@ -47,7 +43,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "da5d715f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +56,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec2d5a6a",
    "metadata": {},
    "source": [
     "If you want to change the location where the demo data and output are stored, you can do so here:"
@@ -70,7 +64,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8e7cc829",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +75,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2386574",
    "metadata": {},
    "source": [
     "Then download the data. The total sample data size is 10.8 GB. This will take several minutes."
@@ -91,7 +83,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "520aa1c5",
    "metadata": {},
    "outputs": [
     {
@@ -114,7 +105,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11aa0d9f",
    "metadata": {},
    "source": [
     "After downloading the data, we generate the parameter file for this demo."
@@ -123,7 +113,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "bf31cbd1",
    "metadata": {},
    "outputs": [
     {
@@ -143,7 +132,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81ab1e49",
    "metadata": {},
    "source": [
     "## Environment"
@@ -151,7 +139,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "647d09fa",
    "metadata": {},
    "source": [
     "[ENSO Metrics package](https://github.com/CLIVAR-PRP/ENSO_metrics) and [scipy](https://www.scipy.org/) installations are needed. This section will clone the ENSO Metrics repository and *install ENSO Metrics and scipy in your current conda environment*. Set the `enso_install_location` below to chose where to clone the ENSO Metrics repository."
@@ -160,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d632f1ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +155,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed720426",
    "metadata": {},
    "source": [
     "To clone and install the ENSO Metrics package, un-comment the next cell and run it (delete quotes in lines 1 & 6)."
@@ -178,7 +163,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "aecd5bcc",
    "metadata": {
     "scrolled": true
    },
@@ -206,7 +190,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "137de9c7",
    "metadata": {},
    "source": [
     "To install scipy, un-comment the next cell and run it (delete quotes in lines 1 & 3)."
@@ -215,7 +198,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "046c7468",
    "metadata": {},
    "outputs": [
     {
@@ -237,7 +219,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab7ac9e8",
    "metadata": {},
    "source": [
     "## Usage"
@@ -245,7 +226,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44577389",
    "metadata": {},
    "source": [
     "The ENSO driver can be run from the command line as `enso_driver.py`. In this notebook, we will use bash cell magic (cells beginning with `%%bash`) to run the ENSO driver as a subprocess."
@@ -253,7 +233,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9059757",
    "metadata": {},
    "source": [
     "For help, type:  \n",
@@ -265,7 +244,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c113d824",
    "metadata": {},
    "outputs": [
     {
@@ -350,7 +328,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0701dc96",
    "metadata": {},
    "source": [
     "### Basic example"
@@ -358,7 +335,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46928faf",
    "metadata": {},
    "source": [
     "Parameters for the ENSO Metrics can be set on the command line or using a parameter file. This first example will use a parameter file, which is shown below."
@@ -367,7 +343,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "70a6b070",
    "metadata": {},
    "outputs": [
     {
@@ -415,7 +390,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92d0e015",
    "metadata": {},
    "source": [
     "The next cell runs the ENSO driver using the basic parameter file. This may take several minutes."
@@ -424,7 +398,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "5f8ef3f9",
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +683,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1da57cf2",
    "metadata": {},
    "source": [
     "This run saved metrics to two files:  \n",
@@ -724,7 +696,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "32ffb4a4",
    "metadata": {},
    "outputs": [
     {
@@ -1120,7 +1091,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d25a4fb7",
    "metadata": {},
    "source": [
     "### ENSO Metrics Collections\n",
@@ -1138,7 +1108,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "931a02c5",
    "metadata": {},
    "outputs": [
     {
@@ -1380,16 +1349,15 @@
     }
    ],
    "source": [
-    "%%bash\n",
+    "%%bash -s \"$demo_output_directory\"\n",
     "enso_driver.py -p basic_enso_param.py \\\n",
     "--metricsCollection ENSO_tel \\\n",
-    "--results_dir 'demo_output/basicTestEnso/ENSO_tel' \\\n",
+    "--results_dir $1/basicTestEnso/ENSO_tel \\\n",
     "--nc_out True"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "da0956e3",
    "metadata": {},
    "source": [
     "All of the results (netCDF and JSON) are located in the output directory, which uses the metrics collection name."
@@ -1398,7 +1366,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "d297d2e5",
    "metadata": {},
    "outputs": [
     {
@@ -1421,7 +1388,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cd7ff92",
    "metadata": {},
    "source": [
     "Finally, this example runs the remaining metrics collection ENSO_proc:"
@@ -1430,7 +1396,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "4ec6cdde",
    "metadata": {},
    "outputs": [
     {
@@ -1868,10 +1833,10 @@
     }
    ],
    "source": [
-    "%%bash\n",
+    "%%bash -s \"$demo_output_directory\"\n",
     "enso_driver.py -p basic_enso_param.py \\\n",
     "--metricsCollection ENSO_proc \\\n",
-    "--results_dir 'demo_output/basicTestEnso/ENSO_proc'"
+    "--results_dir $1/basicTestEnso/ENSO_proc"
    ]
   }
  ],
@@ -1891,7 +1856,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a small fix to the Demo 6 notebook for ENSO. In cells 12 & 14 I had hard-coded the output directory name. Now, the demo_output_directory variable is used to build the output directory name.

I only committed the change to the cells without running the notebook again. After the commit, I tested these two cells in the notebooks and they placed the output data in the correct directory.