### PR TITLE
Add default CIA args

### DIFF
--- a/pcmdi_metrics/driver/pmp_parser.py
+++ b/pcmdi_metrics/driver/pmp_parser.py
@@ -1,5 +1,6 @@
 import cdp.cdp_parser
 import pcmdi_metrics.driver.pmp_parameter
+import pkg_resources
 import os
 import sys
 
@@ -7,12 +8,17 @@ try:
     basestring  # noqa
 except Exception:
     basestring = str
+    
+def path_to_default_args():
+    egg_pth = pkg_resources.resource_filename(pkg_resources.Requirement.parse("pcmdi_metrics"), "share/pmp")
+    file_path = os.path.join(egg_pth, "DefArgsCIA.json")
+    return file_path
 
 
 class PMPParser(cdp.cdp_parser.CDPParser):
     def __init__(self, *args, **kwargs):
         super(PMPParser, self).__init__(pcmdi_metrics.driver.pmp_parameter.PMPParameter,
-                                        os.path.join(sys.prefix, "share", "cia", "DefArgsCIA.json"), *args, **kwargs)
+                                        path_to_default_args(), *args, **kwargs)
         self.use("parameters")
         self.use("diags")
 
@@ -20,7 +26,7 @@ class PMPParser(cdp.cdp_parser.CDPParser):
 class PMPMetricsParser(cdp.cdp_parser.CDPParser):
     def __init__(self, *args, **kwargs):
         super(PMPMetricsParser, self).__init__(pcmdi_metrics.driver.pmp_parameter.PMPMetricsParameter,
-                                               os.path.join(sys.prefix, "share", "cia", "DefArgsCIA.json"),
+                                               path_to_default_args(),
                                                *args, **kwargs)
         self.use("parameters")
         self.use("diags")

--- a/pcmdi_metrics/driver/pmp_parser.py
+++ b/pcmdi_metrics/driver/pmp_parser.py
@@ -2,13 +2,13 @@ import cdp.cdp_parser
 import pcmdi_metrics.driver.pmp_parameter
 import pkg_resources
 import os
-import sys
 
 try:
     basestring  # noqa
 except Exception:
     basestring = str
-    
+
+
 def path_to_default_args():
     """Returns path to Default Common Input Arguments in package egg.
     """

--- a/pcmdi_metrics/driver/pmp_parser.py
+++ b/pcmdi_metrics/driver/pmp_parser.py
@@ -10,6 +10,8 @@ except Exception:
     basestring = str
     
 def path_to_default_args():
+    """Returns path to Default Common Input Arguments in package egg.
+    """
     egg_pth = pkg_resources.resource_filename(pkg_resources.Requirement.parse("pcmdi_metrics"), "share/pmp")
     file_path = os.path.join(egg_pth, "DefArgsCIA.json")
     return file_path

--- a/pcmdi_metrics/graphics/bar_chart/bar_chart.py
+++ b/pcmdi_metrics/graphics/bar_chart/bar_chart.py
@@ -65,7 +65,8 @@ for season in seasons:
         except Exception as err1:
             print(err1)
             try:
-                tmp = float(dd['RESULTS'][mod]["defaultReference"]['r1i1p1']['global'][stat+'_'+season+'_'+domain])  # old format
+                tmp = float(
+                    dd['RESULTS'][mod]["defaultReference"]['r1i1p1']['global'][stat+'_'+season+'_'+domain])  # old format
             except Exception as err2:
                 print(err2)
                 tmp = None

--- a/pcmdi_metrics/graphics/bar_chart/bar_chart.py
+++ b/pcmdi_metrics/graphics/bar_chart/bar_chart.py
@@ -61,12 +61,14 @@ for season in seasons:
     all_mods = []
     for mod in mods:
         try:
-            tmp = float(dd['RESULTS'][mod]["default"]['r1i1p1'][domain][stat][season])  # current format
+            # current format
+            tmp = float(dd['RESULTS'][mod]["default"]['r1i1p1'][domain][stat][season])
         except Exception as err1:
             print(err1)
             try:
+                # old format
                 tmp = float(
-                    dd['RESULTS'][mod]["defaultReference"]['r1i1p1']['global'][stat+'_'+season+'_'+domain])  # old format
+                    dd['RESULTS'][mod]["defaultReference"]['r1i1p1']['global'][stat+'_'+season+'_'+domain])
             except Exception as err2:
                 print(err2)
                 tmp = None

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ print("__git_tag_describe__ = '%s'" % descr, file=f)
 print("__git_sha1__ = '%s'" % commit, file=f)
 f.close()
 
+# Generate and install default arguments    
+p = subprocess.Popen(["python","setup_default_args.py"], cwd="share")
+p.communicate()
+
 portrait_files = ["pcmdi_metrics/graphics/share/portraits.scr", ]
 
 packages = {'pcmdi_metrics': 'src/python',
@@ -110,7 +114,8 @@ data_files = (
                                'share/disclaimer.txt',
                                'share/test_data_files.txt',
                                'share/cmip_model_list.json',
-                               'share/default_regions.py'
+                               'share/default_regions.py',
+                               'share/DefArgsCIA.json'
                             )),
               ('share/pmp/demo', demo_files),
              )

--- a/share/DefArgsCIA.json
+++ b/share/DefArgsCIA.json
@@ -1,0 +1,166 @@
+{
+    "--case_id":{
+        "aliases":[
+            "--cid"
+        ],
+        "default":"None",
+        "dest":"modnames",
+        "help":"The name of the subdirectory (below results_dir where results from a paritcular code execution is stored "
+    },
+    "--diags":{
+        "aliases":[
+            "-d"
+        ],
+        "dest":"other_parameters",
+        "help":"Path to other user-defined parameter file.",
+        "nargs":"+",
+        "required":false,
+        "type":"str"
+    },
+    "--end_day":{
+        "aliases":[
+            "--ed"
+        ],
+        "default":"None",
+        "dest":"endday",
+        "help":"The end day of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--end_month":{
+        "aliases":[
+            "--em"
+        ],
+        "default":"None",
+        "dest":"endmonth",
+        "help":"The end month of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--end_year":{
+        "aliases":[
+            "--ey"
+        ],
+        "default":"None",
+        "dest":"endyear",
+        "help":"The end year of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--exp":{
+        "aliases":[
+            "--EXP"
+        ],
+        "default":"None",
+        "dest":"exp",
+        "help":"An experiment such as AMIP, historical or pi-contorl",
+        "type":"ast.literal_eval"
+    },
+    "--mip":{
+        "aliases":[
+            "--MIP"
+        ],
+        "default":"None",
+        "dest":"mip",
+        "help":"A WCRP MIP project such as CMIP3 and CMIP5",
+        "type":"ast.literal_eval"
+    },
+    "--modnames":{
+        "aliases":[
+            "--mns"
+        ],
+        "default":"None",
+        "dest":"modnames",
+        "help":"A list of names that can be used to loop through modpath",
+        "type":"ast.literal_eval"
+    },
+    "--modpath":{
+        "aliases":[
+            "--mp"
+        ],
+        "dest":"modpath",
+        "help":"Explicit path to model data",
+        "type":"str"
+    },
+    "--num_workers":{
+        "aliases":[
+            "-n"
+        ],
+        "help":"Number of workers, used when running with multiprocessing or in distributed mode.",
+        "required":false,
+        "type":"int"
+    },
+    "--parameters":{
+        "aliases":[
+            "-p"
+        ]
+    },
+    "--reference_data_path":{
+        "aliases":[
+            "--rdp"
+        ],
+        "help":"The path/filename of reference (obs) data.",
+        "type":"str"
+    },
+    "--results_dir":{
+        "aliases":[
+            "--rd"
+        ],
+        "default":"None",
+        "help":"The name of the folder where all runs will be stored.",
+        "type":"str"
+    },
+    "--scheduler_addr\"":{
+        "aliases":[
+            "--N/A"
+        ],
+        "help":"Address of scheduler in the form of IP_ADDRESS:PORT. Used when running in distributed mode.",
+        "required":false,
+        "type":"str"
+    },
+    "--seasons":{
+        "aliases":[
+            "--seas"
+        ],
+        "default":"None",
+        "dest":"sea",
+        "help":"A list of seasons, e.g., [\"DJF\",\"JJA\"]",
+        "type":"ast.literal_eval"
+    },
+    "--start_day":{
+        "aliases":[
+            "--sd"
+        ],
+        "default":"None",
+        "dest":"startday",
+        "help":"The start day of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--start_month":{
+        "aliases":[
+            "--sm"
+        ],
+        "default":"None",
+        "dest":"startmonth",
+        "help":"The start month of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--start_year":{
+        "aliases":[
+            "--sy"
+        ],
+        "default":"None",
+        "dest":"startyear",
+        "help":"The start year of, for example, data to extract from a time series",
+        "type":"ast.literal_eval"
+    },
+    "--test_data_path":{
+        "aliases":[
+            "--tp"
+        ],
+        "help":"The path/filename to model output."
+    },
+    "--variables":{
+        "aliases":[
+            "--vars"
+        ],
+        "help":"A list of variables to be processed"
+    }
+}

--- a/share/setup_default_args.py
+++ b/share/setup_default_args.py
@@ -1,0 +1,55 @@
+from __future__ import print_function
+import os
+import json
+
+#Populate default arguments
+ArgDefaults = {}
+
+ArgDefaults["--parameters"] = {'aliases':["-p"]}
+
+ArgDefaults["--modpath"] = {'aliases':['--mp'],'type':'str', 'dest':'modpath','help':'Explicit path to model data'}
+
+ArgDefaults["--modnames"] = {'aliases':['--mns'],'type':'ast.literal_eval', 'dest':'modnames','default':'None','help':'A list of names that can be used to loop through modpath'}
+
+ArgDefaults["--mip"] = {'aliases':['--MIP'],'type':'ast.literal_eval', 'dest':'mip','default':'None','help':'A WCRP MIP project such as CMIP3 and CMIP5'}
+
+ArgDefaults["--exp"] = {'aliases':['--EXP'],'type':'ast.literal_eval', 'dest':'exp','default':'None','help':'An experiment such as AMIP, historical or pi-contorl'}
+
+ArgDefaults["--start_day"] = {'aliases':['--sd'],'type':'ast.literal_eval', 'dest':'startday','default':'None','help':'The start day of, for example, data to extract from a time series'}
+
+ArgDefaults["--start_month"] = {'aliases':['--sm'],'type':'ast.literal_eval', 'dest':'startmonth','default':'None','help':'The start month of, for example, data to extract from a time series'}
+
+ArgDefaults["--start_year"] = {'aliases':['--sy'],'type':'ast.literal_eval', 'dest':'startyear','default':'None','help':'The start year of, for example, data to extract from a time series'}
+
+ArgDefaults["--end_day"] = {'aliases':['--ed'],'type':'ast.literal_eval', 'dest':'endday','default':'None','help':'The end day of, for example, data to extract from a time series'}
+
+ArgDefaults["--end_month"] = {'aliases':['--em'],'type':'ast.literal_eval', 'dest':'endmonth','default':'None','help':'The end month of, for example, data to extract from a time series'}
+
+ArgDefaults["--end_year"] = {'aliases':['--ey'],'type':'ast.literal_eval', 'dest':'endyear','default':'None','help':'The end year of, for example, data to extract from a time series'}
+
+ArgDefaults["--seasons"] = {'aliases':['--seas'],'type':'ast.literal_eval', 'dest':'sea','default':'None','help':'A list of seasons, e.g., ["DJF","JJA"]'}
+
+ArgDefaults["--results_dir"] = {'aliases':['--rd'],'type':'str', 'default':'None','help':'The name of the folder where all runs will be stored.'}
+
+ArgDefaults["--case_id"] = {'aliases':['--cid'],'dest':'modnames','default':'None','help':'The name of the subdirectory (below results_dir where results from a paritcular code execution is stored '}
+
+ArgDefaults['--reference_data_path'] = {'aliases':['--rdp'],'type':'str','help':'The path/filename of reference (obs) data.'}
+
+ArgDefaults['--test_data_path'] = {'aliases':['--tp'],'help':'The path/filename to model output.'}
+
+ArgDefaults['--diags'] = {'aliases':["-d"],'help':"Path to other user-defined parameter file.","help":"Path to other user-defined parameter file.","type":"str","nargs":"+","required":False,"dest":"other_parameters"}
+
+ArgDefaults['--num_workers'] = {'aliases':["-n"],'help':"Number of workers, used when running with multiprocessing or in distributed mode.","type":"int","required":False}
+
+ArgDefaults['--scheduler_addr"'] = {'aliases':["--N/A"],'help':"Address of scheduler in the form of IP_ADDRESS:PORT. Used when running in distributed mode.","type":"str","required":False}
+
+ArgDefaults['--variables'] = {'aliases':['--vars'],'help':'A list of variables to be processed'}
+
+# Write arguments json
+if os.path.exists('DefArgsCIA.json'):
+    print('File existing, purging: DefArgsCIA.json')
+    os.remove('DefArgsCIA.json')
+
+fH = open('DefArgsCIA.json','w')
+json.dump(ArgDefaults,fH,ensure_ascii=True,sort_keys=True,indent=4,separators=(',',':'))
+fH.close()


### PR DESCRIPTION
The CIA default args JSON is incorporated into the PMP shared files to assist the migration to conda-forge. 

Files:
share/setup_default_args.py: Copy of writejson.py from CIA. Edit arguments here, then run the script to generate share/DefArgsCIA.json
share/DefArgsCIA.json: The JSON containing the default arguments. This is now included in the PMP installation.
setup.py: Added share/DefArgsCIA.json to data_files. Added commands to regenerate DefArgsCIA.json when setup.py is run.
pcmdi_metrics/driver/pmp_parser.py: Get DefaArgsCIA.json file from PMP installation, not from separate CIA package install.

Testing:
To test this, you should create a new environment without the CIA (so don't use the CDAT nightly install). Then try running the mean climate driver.
```
conda create -n test1
conda activate test1
conda install -c conda-forge  python=3.6 cdms2 genutil cdutil cdp matplotlib numpy proj4 jupyterlab nb_conda nb_conda_kernels
python setup.py install
conda list (verify no cia)
```