### PR TITLE
Add python execution shebang

### DIFF
--- a/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
+++ b/pcmdi_metrics/mjo/scripts/mjo_metrics_driver.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Code written by Jiwoo Lee, LLNL. Feb. 2019
 Inspired by Daehyun Kim and Min-Seop Ahn's MJO metrics.


### PR DESCRIPTION
This driver is causing failures in the conda-forge staged recipes PR testing, and I suspect it is because of the lack of "#!/usr/bin/env python" which is found in the other PMP scripts.