### PR TITLE
Add shebang to climatologies script

### DIFF
--- a/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
+++ b/pcmdi_metrics/pcmdi/scripts/pcmdi_compute_climatologies.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import datetime
 
 import cdms2


### PR DESCRIPTION
This script is broken in the conda forge installation without the shebang for using Python. 