### PR TITLE
Import Mapping function from collections.abc to comply with Python 3.10

### DIFF
--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -4,7 +4,8 @@ import json
 import logging
 import os
 import re
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping
 
 import cdat_info
 import cdms2

--- a/pcmdi_metrics/mjo/lib/dict_merge.py
+++ b/pcmdi_metrics/mjo/lib/dict_merge.py
@@ -16,7 +16,6 @@
 #
 # Modifed by Jiwoo Lee, 2020-06-26: Skip merging when dict is empty
 
-import collections
 from collections.abc import Mapping
 
 

--- a/pcmdi_metrics/variability_mode/lib/dict_merge.py
+++ b/pcmdi_metrics/variability_mode/lib/dict_merge.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import collections
 from collections.abc import Mapping
 
 


### PR DESCRIPTION
To be python 3.10 compliance `Mapping` function should be imported from `collections.abc` instead `collections`, following the discussion from https://github.com/conda-forge/pcmdi_metrics-feedstock/pull/6#issuecomment-1151707431

 