### PR TITLE
Update observations in cmec settings files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
       - id: check-yaml
 

--- a/cmec/README.md
+++ b/cmec/README.md
@@ -4,68 +4,70 @@ The cmec-driver software can be obtained from the [cmec-driver repository](https
 
 ## Mean Climate
 1. Edit settings in cmec.json.
-    There are a few parameters you do NOT need to set:
-        `reference_data_path` is assumed to be $CMEC_OBS_DATA
-        `test_data_path` is assumed to be $CMEC_MODEL_DATA
-        `metrics_output_path` is assumed to be $CMEC_WK_DIR
-        Set `compute_climatologies: true` to generate on-the-fly AC files from timeseries.
-2. Move or link observational data to your chosen "obs" dir
-    For example:
-    `ln -s PCMDIobs2_clims obs`
-3. Move or link model data to your chosen "model" directory
-    For example:
-    `ln -s model_data_directory model`
-4. If the observational data file structure has changed, edit the observational data catalogue. Put the path to the new catalogue in the `custom_observations` parameter in cmec.json.
-5. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/mean_climate`
+    There are a few parameters you do NOT need to set:  
+        `reference_data_path` is assumed to be $CMEC_OBS_DATA  
+        `test_data_path` is assumed to be $CMEC_MODEL_DATA  
+        `metrics_output_path` is assumed to be $CMEC_WK_DIR  
+        Set `compute_climatologies: true` to generate on-the-fly AC files from timeseries.  
+2. Move or link observational data to your chosen "obs" dir  
+    For example:  
+    `ln -s PCMDIobs2_clims obs`  
+3. Move or link model data to your chosen "model" directory  
+    For example:  
+    `ln -s model_data_directory model`  
+4. If the observational data file structure has changed, edit the observational data catalogue. Put the path to the new catalogue in the `custom_observations` parameter in cmec.json.  
+5. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/mean_climate`  
 
 ## Modes of variability
-1. Edit settings in cmec.json.
-    `modpath` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.
-    The `ObsUnitsAdjust` and `ModUnitsAdjust` tuples should be encased in quotes (e.g. `"ObsUnitsAdjust": "(True, 'divide', 100.0)"`)
-2. Move or link observational data to your chosen "obs" dir
-3. Move or link model data to your chosen "model" dir
-4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/variability_modes`
+1. Edit settings in cmec.json.  
+    `modpath` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.  
+    The `ObsUnitsAdjust` and `ModUnitsAdjust` tuples should be encased in quotes (e.g. `"ObsUnitsAdjust": "(True, 'divide', 100.0)"`)  
+2. Move or link observational data to your chosen "obs" dir  
+3. Move or link model data to your chosen "model" dir  
+4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/variability_modes`  
 
 ## MJO
-1. Edit settings in cmec.json
-2. Move or link observational data to your chosen "obs" dir
-3. Move or link model data to your chosen "model" dir
-4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/mjo`
+1. Edit settings in cmec.json  
+2. Move or link observational data to your chosen "obs" dir  
+3. Move or link model data to your chosen "model" dir  
+4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/mjo`  
 
 ## Monsoon (Wang)
-1. Edit settings in cmec.json.
-    `test_data_path` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.
-    The `threshold` variable needs to be in the same units as your input data. The default is 2.5 mm / 86400 = 2.894e-05 for model input with  units of kg m-2 s-1.
-2. Move or link observational data to your chosen "obs" dir
-3. Move or link model data to your chosen "model" dir
-4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/monsoon_wang`
+1. Edit settings in cmec.json.  
+    `test_data_path` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.  
+    The `threshold` variable needs to be in the same units as your input data. The default is 2.5 mm / 86400 = 2.894e-05 for model input with  units of kg m-2 s-1.  
+2. Move or link observational data to your chosen "obs" dir  
+3. Move or link model data to your chosen "model" dir  
+4. Run cmec driver: `python cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/monsoon_wang`  
 
 ## Monsoon (Sperber)
-1. Edit settings in cmec.json
-    `modpath` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.
-    `modpath_lf` and `reference_data_lf` path are also relative to the above directories.
-    The `ObsUnitsAdjust` and `ModUnitsAdjust` tuples should be encased in quotes (e.g. `"ObsUnitsAdjust": "(True, 'divide', 100.0)"`)
-3. Move or link observational data to your chosen "obs" dir
-4. Move or link model data to your chosen "model" dir
-5. Run cmec driver: python `cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/monsoon_sperber`
+1. Edit settings in cmec.json  
+    `modpath` and `reference_data_path` are relative to the CMEC $CMEC_MODEL_DATA and $CMEC_OBS_DATA directories, respectively.  
+    `modpath_lf` and `reference_data_lf` path are also relative to the above directories.  
+    The `ObsUnitsAdjust` and `ModUnitsAdjust` tuples should be encased in quotes (e.g. `"ObsUnitsAdjust": "(True, 'divide', 100.0)"`)  
+3. Move or link observational data to your chosen "obs" dir  
+4. Move or link model data to your chosen "model" dir  
+5. Run cmec driver: python `cmec-driver.py run -obs <obs dir> <model dir> <output dir> PMP/monsoon_sperber`  
 
 ## Diurnal Cycle of Precipitation
-1. Edit settings in cmec.json
-    `filename_template` is relative to your $CMEC_MODEL_DATA directory. This should be 3hr precipitation data.
-    Do not set `modpath` as this is your $CMEC_MODEL_DATA directory.
-2. Move or link model data to your chosen "model" dir
-3. Run cmec driver: `python cmec-driver.py run <model dir> <output dir> PMP/diurnal_cycle`
+1. Edit settings in cmec.json  
+    `filename_template` is relative to your $CMEC_MODEL_DATA directory. This should be 3hr precipitation data.  
+    Do not set `modpath` as this is your $CMEC_MODEL_DATA directory.  
+2. Move or link model data to your chosen "model" dir  
+3. Run cmec driver: `python cmec-driver.py run <model dir> <output dir> PMP/diurnal_cycle`  
 
 ### Running multiple metrics
-Follow all but the final step for your chosen metrics. To run all the metrics via cmec-driver, run:
-`cmec-driver.py run -obs <obs dir> <model dir> <output dir> <list metrics names>`
-For example:
-`python cmec-driver.py run -obs obs model output PMP/mjo PMP/monsoon_wang PMP/diurnal_cycle`
-It is not guaranteed that the metrics will run in the same order that they are listed in your run statement.
+Follow all but the final step for your chosen metrics. To run all the metrics via cmec-driver, run:  
+`cmec-driver.py run -obs <obs dir> <model dir> <output dir> <list metrics names>`  
+For example:  
+`python cmec-driver.py run -obs obs model output PMP/mjo PMP/monsoon_wang PMP/diurnal_cycle`  
+It is not guaranteed that the metrics will run in the same order that they are listed in your run statement.  
 
 ### Other tips for the configuration file
-True and False values in the JSON standard are represented by `true` and `false`. For the PMP metrics, users can also use the strings `"True"` and `"False"`, though this is not recommended.
-The PMP parameter files accept python functions and datatypes that are not valid JSON objects. Any parameter values that are function calls, tuples, or other non-JSON types should be encased in quotes.
+True and False values in the JSON standard are represented by `true` and `false`. For the PMP metrics, users can also use the strings `"True"` and `"False"`, though this is not recommended.  
+
+The PMP parameter files accept python functions and datatypes that are not valid JSON objects. Any parameter values that are function calls, tuples, or other non-JSON types should be encased in quotes.  
+
 The "datetime", "glob", and "os" packages are available in the parameter files generated during this workflow. These packages can be used to set parameter values in cmec.json. For example, a user can set `"case_id": "datetime.datetime.now().strftime('v%Y%m%d')"` to have the case_id reflect the date.
 
 # Information for Developers
@@ -77,14 +79,14 @@ CMEC driver first looks at the contents.json file to find the settings file for 
 ## Steps for adding a new metric
 1. Create a folder for the metric under cmec/.
 2. Write a driver bash script for the metric. This script should contain the entire workflow for generating the metric, including activating the PMP conda environment, generating a parameter file, running the metric, and generating metadata, as needed (for example, see mean_climate/pmp_mean_climate_driver.sh.
-3. Write a settings file (for example, see mean_climate/pmp_mean_climate.json):
-- The required keys are "settings", "varlist", and "obslist".
-- The required keys under settings are "name", "long_name", and "driver".
-- Add the driver file path (relative to pcmdi_metrics/) to "settings":"driver".
-- Under "default_parameters" it is recommended that you provide the full settings needed to run a sample case out-of-the-box, using the same sample data as the Demo jupyter notebook.
-5. Add the settings file path to pcmdi_metrics/contents.json in the "contents" list.
-6. If there is any special processing that needs to happen to the input parameters, add that code to scripts/pmp_param_generator.py
+3. Write a settings file (for example, see mean_climate/pmp_mean_climate.json):  
+- The required keys are "settings", "varlist", and "obslist".  
+- The required keys under settings are "name", "long_name", and "driver".  
+- Add the driver file path (relative to pcmdi_metrics/) to "settings":"driver".  
+- Under "default_parameters" it is recommended that you provide the full settings needed to run a sample case out-of-the-box, using the same sample data as the Demo jupyter notebook.  
+5. Add the settings file path to pcmdi_metrics/contents.json in the "contents" list.  
+6. If there is any special processing that needs to happen to the input parameters, add that code to scripts/pmp_param_generator.py  
 7. If any other scripts are created to help run the metric in cmec-driver, save them under scripts/ or in the metric folder.
-8. If the metric does not output its own metadata JSON, write a script to generate one (for example, see mean_climate/mean_climate_output.py). This script should be included in the driver script workflow (for example, see mean_climate/pmp_mean_climate_driver.sh).
-9. (Optional) Add an html page that displays the results of your metric.
-10. Test by running your new metric in cmec-driver. Check that it produces the output files that you expect and that they are correctly documented in your output metadata file.
+8. If the metric does not output its own metadata JSON, write a script to generate one (for example, see mean_climate/mean_climate_output.py). This script should be included in the driver script workflow (for example, see mean_climate/pmp_mean_climate_driver.sh).  
+9. (Optional) Add an html page that displays the results of your metric.  
+10. Test by running your new metric in cmec-driver. Check that it produces the output files that you expect and that they are correctly documented in your output metadata file.  

--- a/cmec/mjo/pmp_mjo.json
+++ b/cmec/mjo/pmp_mjo.json
@@ -15,9 +15,9 @@
         }
     },
     "obslist": {
-        "GPCP-IP": {
-            "version": "IP",
-            "long_name": "GPCP IP Merged Precipitation",
+        "NASA-JPL GPCP-1-3": {
+            "version": "GPCP-1-3",
+            "long_name": "GPCP-1-3 Merged Precipitation",
             "description": "GPCP daily data prepared for PMPObs (ODS-v2.1.0)"
         }
     },
@@ -33,7 +33,7 @@
         "ModUnitsAdjust": "(True, 'multiply', 86400.0, 'mm d-1')",
         "units": "mm/day",
         "reference_data_name": "GPCP-IP",
-        "reference_data_path": "PCMDIobs2/atmos/day/pr/GPCP-IP/gn/v20200719/pr.day.GPCP-IP.BE.gn.v20200719.1998-1999.xml",
+        "reference_data_path": "obs4MIPs_PCMDI_daily/NASA-JPL/GPCP-1-3/day/pr/gn/latest/pr_day_GPCP-1-3_PCMDI_gn_19961002-20170101.nc",
         "varOBS": "pr",
         "ObsUnitsAdjust": "(True, 'multiply', 86400.0, 'mm d-1')",
         "osyear": 1998,

--- a/cmec/monsoon_sperber/pmp_monsoon_sperber.json
+++ b/cmec/monsoon_sperber/pmp_monsoon_sperber.json
@@ -15,9 +15,9 @@
         }
     },
     "obslist": {
-        "GPCP-IP": {
-            "version": "IP",
-            "long_name": "GPCP IP Merged Precipitation",
+        "NASA-JPL GPCP-1-3": {
+            "version": "GPCP-1-3",
+            "long_name": "GPCP-1-3 Merged Precipitation",
             "description": "GPCP daily data prepared for PMPObs (ODS-v2.1.0)"
         }
     },
@@ -34,8 +34,8 @@
         "units": "mm/d",
         "msyear": 2000,
         "meyear": 2005,
-        "reference_data_name": "GPCP-IP",
-        "reference_data_path": "PCMDIobs2/atmos/day/pr/GPCP-IP/gn/v20200719/pr.day.GPCP-IP.BE.gn.v20200719.1998-1999.xml",
+        "reference_data_name": "GPCP-1-3",
+        "reference_data_path": "obs4MIPs_PCMDI_daily/NASA-JPL/GPCP-1-3/day/pr/gn/latest/pr_day_GPCP-1-3_PCMDI_gn_19961002-20170101.nc",
         "reference_data_lf_path": "misc_demo_data/fx/sftlf.GPCP-IP.1x1.nc",
         "varOBS": "pr",
         "ObsUnitsAdjust": "(True, 'multiply', 86400.0)",

--- a/cmec/monsoon_wang/pmp_monsoon_wang.json
+++ b/cmec/monsoon_wang/pmp_monsoon_wang.json
@@ -26,7 +26,7 @@
             "CanCM4"
         ],
         "test_data_path": "CMIP5_demo_clims/cmip5.historical.%(model).r1i1p1.mon.pr.198101-200512.AC.v20200426.nc",
-        "reference_data_path": "PCMDIobs2/atmos/mon/pr/GPCP-2-3/gn/v20200707/pr_mon_GPCP-2-3_BE_gn_v20200707_197901-201907.nc",
+        "reference_data_path": "obs4MIPs_PCMDI_monthly/NOAA-NCEI/GPCP-2-3/mon/pr/gn/v20210727/pr_mon_GPCP-2-3_PCMDI_gn_197901-201907.nc",
         "threshold": 0.00002894
     }
 }

--- a/cmec/mov/pmp_mov.json
+++ b/cmec/mov/pmp_mov.json
@@ -47,7 +47,7 @@
         "meyear": 2005,
         "eofn_mod": 1,
         "reference_data_name": "NOAA-20CR",
-        "reference_data_path": "PCMDIobs2/atmos/mon/psl/20CR/gn/v20200707/psl_mon_20CR_BE_gn_v20200707_187101-201212.nc",
+        "reference_data_path": "obs4MIPs_PCMDI_monthly/NOAA-ESRL-PSD/20CR/mon/psl/gn/v20210727/psl_mon_20CR_PCMDI_gn_187101-201212.nc",
         "varOBS": "psl",
         "ObsUnitsAdjust": "(True, 'divide', 100.0)",
         "osyear": 1900,


### PR DESCRIPTION
There are 3 items in this pr:
1. I updated the links to new obs data in the cmec settings json files
2. I fixed the spacing in the README for the CMEC directory
3. I added a setting to the pre-commit configuration to skip the "trailing whitespace" check for markdown files, which use trailing whitespace to indicate line breaks.
