### PR TITLE
Increase timeout for github action build test

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -48,7 +48,7 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Github action test for build was failing after 5 min from starting, thus increasing it to 10 min.