### PR TITLE
Replace `setup.py` versioning scheme with standard convention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
       hooks:
           - id: black
 
-    - repo: https://github.com/timothycrosley/isort
-      rev: 5.10.1
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.12.0
       hooks:
           - id: isort
 

--- a/pcmdi_metrics/version.py
+++ b/pcmdi_metrics/version.py
@@ -1,3 +1,3 @@
-__version__ = '2.5.1'
-__git_tag_describe__ = '2.5.1'
-__git_sha1__ = '4521f5928dd618bba00d5bc6517065f2974dcffc'
+__version__ = "v2.4.0"
+__git_tag_describe__ = "v2.4.0-34-gcb5f9165"
+__git_sha1__ = "cb5f9165a6f7dc17f8865d7bdfa8e0e54741eceb"

--- a/pcmdi_metrics/version.py
+++ b/pcmdi_metrics/version.py
@@ -1,3 +1,3 @@
-__version__ = "v2.4.0"
-__git_tag_describe__ = "v2.4.0-34-gcb5f9165"
-__git_sha1__ = "cb5f9165a6f7dc17f8865d7bdfa8e0e54741eceb"
+__version__ = '2.5.1'
+__git_tag_describe__ = '2.5.1'
+__git_sha1__ = '4521f5928dd618bba00d5bc6517065f2974dcffc'

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,7 @@ if "--enable-devel" in sys.argv:
 else:
     install_dev = False
 
-Version = "2.0"
-p = subprocess.Popen(
-    ("git", "describe", "--tags"),
-    stdin=subprocess.PIPE,
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-)
-try:
-    descr = p.stdout.readlines()[0].strip().decode("utf-8")
-    Version = "-".join(descr.split("-")[:-2])
-    if Version == "":
-        Version = descr
-except Exception:
-    descr = Version
+release_version = "2.5.1"
 
 p = subprocess.Popen(
     ("git", "log", "-n1", "--pretty=short"),
@@ -38,9 +25,10 @@ try:
     commit = p.stdout.readlines()[0].split()[1].decode("utf-8")
 except Exception:
     commit = ""
+
 f = open("pcmdi_metrics/version.py", "w")
-print("__version__ = '%s'" % Version, file=f)
-print("__git_tag_describe__ = '%s'" % descr, file=f)
+print("__version__ = '%s'" % release_version, file=f)
+print("__git_tag_describe__ = '%s'" % release_version, file=f)
 print("__git_sha1__ = '%s'" % commit, file=f)
 f.close()
 
@@ -143,7 +131,7 @@ if install_dev:
 
 setup(
     name="pcmdi_metrics",
-    version=descr,
+    version=release_version,
     author="PCMDI",
     description="model metrics tools",
     url="http://github.com/PCMDI/pcmdi_metrics",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ try:
         Version = descr
 except Exception:
     descr = release_version
+    Version = release_version
 
 p = subprocess.Popen(
     ("git", "log", "-n1", "--pretty=short"),

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,20 @@ else:
 release_version = "2.5.1"
 
 p = subprocess.Popen(
+    ("git", "describe", "--tags"),
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+try:
+    descr = p.stdout.readlines()[0].strip().decode("utf-8")
+    Version = "-".join(descr.split("-")[:-2])
+    if Version == "":
+        Version = descr
+except Exception:
+    descr = release_version
+
+p = subprocess.Popen(
     ("git", "log", "-n1", "--pretty=short"),
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
@@ -28,7 +42,7 @@ except Exception:
 
 f = open("pcmdi_metrics/version.py", "w")
 print("__version__ = '%s'" % release_version, file=f)
-print("__git_tag_describe__ = '%s'" % release_version, file=f)
+print("__git_tag_describe__ = '%s'" % descr, file=f)
 print("__git_sha1__ = '%s'" % commit, file=f)
 f.close()
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ except Exception:
     commit = ""
 
 f = open("pcmdi_metrics/version.py", "w")
-print("__version__ = '%s'" % release_version, file=f)
+print("__version__ = '%s'" % Version, file=f)
 print("__git_tag_describe__ = '%s'" % descr, file=f)
 print("__git_sha1__ = '%s'" % commit, file=f)
 f.close()


### PR DESCRIPTION
- Closes #893 
- A workaround to the issue with `setuptools>=6.6.0` enforcing PEP440 which was breaking the local package build process for `pcmdi_metrics`.
- Bumps `isort` `pre-commit` hook to fix a [bug](https://github.com/PyCQA/isort/issues/2077) that breaks the GH Actions build.

## Notes
When bumping `pcmdi_metrics` for a new release, make sure to update `release_version` in `setup.py`. 

Also, local builds should be installed using `python -m pip install .` rather than `python setup.py install`.

## Output
```bash
(pmp_dev) vo13@ml-9704174 pcmdi_metrics % python -m pip install .
Processing /Users/vo13/Documents/Repositories/PCMDI/pcmdi_metrics
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: pcmdi-metrics
  Building wheel for pcmdi-metrics (PEP 517) ... done
  Created wheel for pcmdi-metrics: filename=pcmdi_metrics-2.5.1-py3-none-any.whl size=1697808 sha256=8eb25d25440ffa247bd2f35c26c212c68bf0cb25d82f6870d2a4e6f4bac54203
  Stored in directory: /private/var/folders/_h/t3wvkks5643fxnv07_kx9cx8000zpt/T/pip-ephem-wheel-cache-e2in5dui/wheels/dd/f6/e5/9a3d70fd7e89a7d0485da7c363747fffce8f6596dab2b28068
Successfully built pcmdi-metrics
Installing collected packages: pcmdi-metrics
Successfully installed pcmdi-metrics-2.5.1
```