### PR TITLE
Bug fix for MJO metrics

### DIFF
--- a/pcmdi_metrics/mjo/lib/mjo_metric_calc.py
+++ b/pcmdi_metrics/mjo/lib/mjo_metric_calc.py
@@ -89,7 +89,7 @@ def mjo_metric_ewr_calculation(
     # Store each year's segment in a dictionary: segment[year]
     segment = {}
     segment_ano = {}
-    daSeaCyc = MV2.zeros((NT, d.shape[1], d.shape[2]), MV2.float)
+    daSeaCyc = MV2.zeros((NT, d.shape[1], d.shape[2]))
     for year in range(startYear, endYear):
         print(year)
         segment[year] = subSliceSegment(d, year, mon, day, NT)


### PR DESCRIPTION
To prevent a warning sign like below:
`warning: failed for  GISS-E2-H r1i1p1 module 'MV2' has no attribute 'float'`