### PR TITLE
Add custom target grid to mean climate

### DIFF
--- a/pcmdi_metrics/mean_climate/lib/create_mean_climate_parser.py
+++ b/pcmdi_metrics/mean_climate/lib/create_mean_climate_parser.py
@@ -98,6 +98,7 @@ def create_mean_climate_parser():
         dest="target_grid",
         help='Options are "2.5x2.5" or an actual cdms2 grid object',
         required=False,
+        default="2.5x2.5"
     )
 
     parser.add_argument(

--- a/pcmdi_metrics/mean_climate/mean_climate_driver.py
+++ b/pcmdi_metrics/mean_climate/mean_climate_driver.py
@@ -101,24 +101,31 @@ print(
 print('--- prepare mean climate metrics calculation ---')
 
 # generate target grid
-if target_grid == "2.5x2.5":
-    # target grid for regridding
-    t_grid = xc.create_uniform_grid(-88.875, 88.625, 2.5, 0, 357.5, 2.5)
-    if debug:
-        print('type(t_grid):', type(t_grid))  # Expected type is 'xarray.core.dataset.Dataset'
-        print('t_grid:', t_grid)
-    # identical target grid in cdms2 to use generateLandSeaMask function that is yet to exist in xcdat
-    t_grid_cdms2 = cdms2.createUniformGrid(-88.875, 72, 2.5, 0, 144, 2.5)
-    # generate land sea mask for the target grid
-    sft = cdutil.generateLandSeaMask(t_grid_cdms2)
-    if debug:
-        print('sft:', sft)
-        print('sft.getAxisList():', sft.getAxisList())
-    # add sft to target grid dataset
-    t_grid['sftlf'] = (['lat', 'lon'], np.array(sft))
-    if debug:
-        print('t_grid (after sftlf added):', t_grid)
-        t_grid.to_netcdf('target_grid.nc')
+res=target_grid.split("x")
+lat_res=float(res[0])
+lon_res=float(res[1])
+start_lat=-90+lat_res/2
+start_lon=0
+end_lat = 90-lat_res/2
+end_lon = 360-lon_res
+nlat = ((end_lat - start_lat) * 1/lat_res) + 1
+nlon = ((end_lon - start_lon) * 1/lon_res) + 1
+t_grid=xc.create_uniform_grid(start_lat,end_lat,lat_res,start_lon,end_lon,lon_res)
+if debug:
+    print('type(t_grid):', type(t_grid))  # Expected type is 'xarray.core.dataset.Dataset'
+    print('t_grid:', t_grid)
+# identical target grid in cdms2 to use generateLandSeaMask function that is yet to exist in xcdat
+t_grid_cdms2 = cdms2.createUniformGrid(start_lat,nlat,lat_res,start_lon,nlon,lon_res)
+# generate land sea mask for the target grid
+sft = cdutil.generateLandSeaMask(t_grid_cdms2)
+if debug:
+    print('sft:', sft)
+    print('sft.getAxisList():', sft.getAxisList())
+# add sft to target grid dataset
+t_grid['sftlf'] = (['lat', 'lon'], np.array(sft))
+if debug:
+    print('t_grid (after sftlf added):', t_grid)
+    t_grid.to_netcdf('target_grid.nc')
 
 # load obs catalogue json
 egg_pth = resources.resource_path()

--- a/pcmdi_metrics/mean_climate/mean_climate_driver.py
+++ b/pcmdi_metrics/mean_climate/mean_climate_driver.py
@@ -105,12 +105,12 @@ print('--- prepare mean climate metrics calculation ---')
 res=target_grid.split("x")
 lat_res=float(res[0])
 lon_res=float(res[1])
-start_lat=-90+lat_res/2
-start_lon=0
-end_lat = 90-lat_res/2
-end_lon = 360-lon_res
-nlat = ((end_lat - start_lat) * 1/lat_res) + 1
-nlon = ((end_lon - start_lon) * 1/lon_res) + 1
+start_lat=-90.+lat_res/2
+start_lon=0.
+end_lat = 90.-lat_res/2
+end_lon = 360.-lon_res
+nlat = ((end_lat - start_lat) * 1./lat_res) + 1
+nlon = ((end_lon - start_lon) * 1./lon_res) + 1
 t_grid=xc.create_uniform_grid(start_lat,end_lat,lat_res,start_lon,end_lon,lon_res)
 if debug:
     print('type(t_grid):', type(t_grid))  # Expected type is 'xarray.core.dataset.Dataset'


### PR DESCRIPTION
How it works: 
The "target_grid" variable is set to the desired LATxLON spacing, in degrees. For example, "1x1.25" will set a target grid with resolution of 1 degrees latitude and 1.25 degrees longitude.  A default of 2.5x2.5 degrees is set in the mean climate parser.

There is a slight change in how the 2.5x2.5 degree case is handled from what is currently in PMP v3.1.1. The starting latitude is -90+0.5*latitude_resolution, versus -88.875. This was tested using the baseline case from the mean climate demo notebook, and I found that the metrics are identical to the hundreths or thousandths place.