### PR TITLE
Remove genutil from precip variability

### DIFF
--- a/pcmdi_metrics/precip_variability/lib/lib_variability_across_timescales.py
+++ b/pcmdi_metrics/precip_variability/lib/lib_variability_across_timescales.py
@@ -63,7 +63,7 @@ def precip_variability_across_timescale(
     # Write data (nc file)
     outfilename = "PS_pr." + str(dfrq) + "_regrid.180x90_" + dat + ".nc"
     custom_dataset = xr.merge([freqs, ps, rn, sig95])
-    custom_dataset.to_netcdf(path=os.path.join(outdir(output_type="diagnostic_results"), outfilename))
+    custom_dataset.to_netcdf(path=os.path.join(outdir.replace("%(output_type)","diagnostic_results"), outfilename))
         
     # Power spectum of anomaly
     freqs, ps, rn, sig95 = Powerspectrum(anom, nperseg, noverlap)
@@ -72,7 +72,7 @@ def precip_variability_across_timescale(
     # Write data (nc file)
     outfilename = "PS_pr." + str(dfrq) + "_regrid.180x90_" + dat + "_unforced.nc"
     custom_dataset = xr.merge([freqs, ps, rn, sig95])
-    custom_dataset.to_netcdf(path=os.path.join(outdir(output_type="diagnostic_results"), outfilename))
+    custom_dataset.to_netcdf(path=os.path.join(outdir.replace("%(output_type)","diagnostic_results"), outfilename))
         
     # Write data (json file)
     psdmfm["RESULTS"][dat] = {}
@@ -83,7 +83,7 @@ def precip_variability_across_timescale(
         "PS_pr." + str(dfrq) + "_regrid.180x90_area.freq.mean_" + dat + ".json"
     )
     JSON = pcmdi_metrics.io.base.Base(
-        outdir(output_type="metrics_results"), outfilename
+        outdir.replace("%(output_type)","metrics_results"), outfilename
     )
     JSON.write(
         psdmfm,

--- a/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
+++ b/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
@@ -32,7 +32,7 @@ cmec = param.cmec
 
 # Create output directory
 case_id = param.case_id
-outdir_template = param.process_templated_argument("results_dir")
+outdir_template = param.results_dir
 outdir_template = outdir_template.replace("%(mip)",mip).replace("%(case_id)",case_id)
 for output_type in ["graphics", "diagnostic_results", "metrics_results"]:
     outdir = outdir_template.replace("%(output_type)",output_type)

--- a/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
+++ b/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
@@ -3,8 +3,6 @@
 import glob
 import os
 
-from genutil import StringConstructor
-
 from pcmdi_metrics.mean_climate.lib.pmp_parser import PMPParser
 from pcmdi_metrics.precip_variability.lib import (
     AddParserArgument,
@@ -38,9 +36,11 @@ outdir_template = param.process_templated_argument("results_dir")
 outdir = StringConstructor(
     str(outdir_template(output_type="%(output_type)", mip=mip, case_id=case_id))
 )
+outdir_template = outdir_template.replace("%(mip)",mip).replace("%(case_id)",case_id)
 for output_type in ["graphics", "diagnostic_results", "metrics_results"]:
-    os.makedirs(outdir(output_type=output_type), exist_ok=True)
-    print(outdir(output_type=output_type))
+    outdir = outdir_template.replace("%(output_type)",output_type)
+    os.makedirs(outdir, exist_ok=True)
+    print(outdir)
 
 # Check data in advance
 file_list = sorted(glob.glob(os.path.join(modpath, mod)))
@@ -57,5 +57,5 @@ print(file_list)
 syr = prd[0]
 eyr = prd[1]
 precip_variability_across_timescale(
-        file_list, syr, eyr, dfrq, mip, dat, var, fac, nperseg, noverlap, outdir, cmec
+        file_list, syr, eyr, dfrq, mip, dat, var, fac, nperseg, noverlap, outdir_template, cmec
     )

--- a/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
+++ b/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
@@ -33,7 +33,7 @@ cmec = param.cmec
 # Create output directory
 case_id = param.case_id
 outdir_template = param.results_dir
-outdir_template = outdir_template.replace("%(mip)",mip).replace("%(case_id)",case_id)
+outdir_template = outdir_template.replace("%(mip)",str(mip)).replace("%(case_id)",str(case_id))
 for output_type in ["graphics", "diagnostic_results", "metrics_results"]:
     outdir = outdir_template.replace("%(output_type)",output_type)
     os.makedirs(outdir, exist_ok=True)

--- a/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
+++ b/pcmdi_metrics/precip_variability/variability_across_timescales_PS_driver.py
@@ -33,9 +33,6 @@ cmec = param.cmec
 # Create output directory
 case_id = param.case_id
 outdir_template = param.process_templated_argument("results_dir")
-outdir = StringConstructor(
-    str(outdir_template(output_type="%(output_type)", mip=mip, case_id=case_id))
-)
 outdir_template = outdir_template.replace("%(mip)",mip).replace("%(case_id)",case_id)
 for output_type in ["graphics", "diagnostic_results", "metrics_results"]:
     outdir = outdir_template.replace("%(output_type)",output_type)


### PR DESCRIPTION
This PR is to remove the genutil dependency from the Precip Variability metrics. Instead, the Python replace function is used to substitute variables into the results directory file name.

This branch has been tested using the examples from the precip variability notebook. I created an additional test case that made use of the %(output_type) and %(case_id) variables to test those substitutions.