### PR TITLE
environment.yml for binderhub on LLNL nimbus

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,1 @@
+./conda-env/dev.yml


### PR DESCRIPTION
To enable PMP usage in the BinderHub of the LLNL's Nimbus machine, environment.yml is needed. It has the same content as the conda-env/dev.yml, thus instead of duplicating, symlink is added.