### PR TITLE
BinderHub updates

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -eux
+python -m pip install -vv --no-deps --no-build-isolation -e .

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,11 @@
+dvipng
+ghostscript
+texlive-fonts-recommended
+texlive-generic-recommended
+texlive-latex-base
+texlive-latex-extra
+texlive-latex-recommended
+texlive-publishers
+texlive-science
+texlive-xetex
+cm-super


### PR DESCRIPTION
This PR adds updates for BinderHub
- Adds `postBuild` to support installing package
- Adds `apt.txt` to support saving pdfs