### PR TITLE
Add link to docs in Sea ice demo

### DIFF
--- a/doc/jupyter/Demo/Demo_9_seaIceExtent_ivanova.ipynb
+++ b/doc/jupyter/Demo/Demo_9_seaIceExtent_ivanova.ipynb
@@ -60,7 +60,7 @@
     "Ivanova, D. P., P. J. Gleckler, K. E. Taylor, P. J. Durack, and K. D. Marvel, 2016: Moving beyond the Total Sea Ice Extent in Gauging Model Biases. J. Climate, 29, 8965–8987, https://doi.org/10.1175/JCLI-D-16-0026.1. \n",
     "\n",
     "**NOTE**  \n",
-    "The installation instruction for the PMP can be found [here](http://pcmdi.github.io/pcmdi_metrics/install.html).  \n",
+    "The installation instructions for the PMP can be found [here](http://pcmdi.github.io/pcmdi_metrics/install.html).  \n",
     "The documentation for the sea ice metrics can be found [here](http://pcmdi.github.io/pcmdi_metrics/metrics_sea_ice.html)."
    ]
   },

--- a/doc/jupyter/Demo/Demo_9_seaIceExtent_ivanova.ipynb
+++ b/doc/jupyter/Demo/Demo_9_seaIceExtent_ivanova.ipynb
@@ -60,7 +60,8 @@
     "Ivanova, D. P., P. J. Gleckler, K. E. Taylor, P. J. Durack, and K. D. Marvel, 2016: Moving beyond the Total Sea Ice Extent in Gauging Model Biases. J. Climate, 29, 8965–8987, https://doi.org/10.1175/JCLI-D-16-0026.1. \n",
     "\n",
     "**NOTE**  \n",
-    "The installation instruction for the PMP can be found [here](http://pcmdi.github.io/pcmdi_metrics/install.html)."
+    "The installation instruction for the PMP can be found [here](http://pcmdi.github.io/pcmdi_metrics/install.html).  \n",
+    "The documentation for the sea ice metrics can be found [here](http://pcmdi.github.io/pcmdi_metrics/metrics_sea_ice.html)."
    ]
   },
   {
@@ -169,7 +170,7 @@
    "id": "bf862633",
    "metadata": {},
    "source": [
-    "**NOTE** Further explore for the above datasets can be found in our supplemental Jupyter notebook: [Demo_9b_seaIce_data_explore.ipynb](Demo_9b_seaIce_data_explore.ipynb)"
+    "**NOTE** Further exploration of the above datasets can be found in our supplemental Jupyter notebook: [Demo_9b_seaIce_data_explore.ipynb](Demo_9b_seaIce_data_explore.ipynb)"
    ]
   },
   {
@@ -2906,7 +2907,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pcmdi_metrics_dev_20231129",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2920,7 +2921,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I've added a link to the GitHub.io documentation page for the sea ice metrics, and fixed a small typo.