### PR TITLE
Update dev environment

### DIFF
--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -24,9 +24,9 @@ dependencies:
     - xcdat>=0.7.0
     - xmltodict=0.13.0
     - setuptools=67.7.2
-    - netcdf4=1.6.3
+    - netcdf4>=1.6.3
     - regionmask=0.9.0
-    - rasterio=1.3.6
+    - rasterio>=1.3.6
     - shapely=2.0.1
     - numdifftools
     - nc-time-axis


### PR DESCRIPTION
I found that loosening the version restrictions on the rasterio and netcdf4 libraries allows for the latest version of esmpy to be installed in the dev environment. This update is intended to fix the failures in the CI build stage.