### PR TITLE
Add tuple fix function

### DIFF
--- a/pcmdi_metrics/utils/adjust_units.py
+++ b/pcmdi_metrics/utils/adjust_units.py
@@ -26,6 +26,7 @@ def adjust_units(da: xr.DataArray, adjust_tuple: tuple) -> xr.DataArray:
             da.assign_attrs(units=adjust_tuple[3])
     return da
 
+
 def fix_tuple(target: tuple) -> tuple:
     """Fix formatting of tuple read from the command line.
 

--- a/pcmdi_metrics/utils/adjust_units.py
+++ b/pcmdi_metrics/utils/adjust_units.py
@@ -25,3 +25,22 @@ def adjust_units(da: xr.DataArray, adjust_tuple: tuple) -> xr.DataArray:
         if len(adjust_tuple) > 3:
             da.assign_attrs(units=adjust_tuple[3])
     return da
+
+def fix_tuple(target: tuple) -> tuple:
+    """Fix formatting of tuple read from the command line.
+
+    Parameters
+    ----------
+    tuple : tuple
+        Any tuple
+
+    Returns
+    -------
+    target: tuple
+        The tuple is reformatted as needed.
+    """
+    if target[0] == "(":
+        # Tuple has been split by character rather than commas
+        target = "".join(target)
+        target = eval(target)
+    return target


### PR DESCRIPTION
When a tuple such as ModUnitsAdjust is read from the command line, it is split by character and not usable in this format. 

For example, the tuple `(True, 'multiply', 1e-2)` gets parsed as `('(', 'T', 'r', 'u', 'e', ',', ' ', "'", 'm', 'u', 'l', 't', 'i', 'p', 'l', 'y', "'", ',', ' ', '1', 'e', '-', '2', ')')`.

This function re-formats the tuple so that it will be correctly formatted as `(True, 'multiply', 0.01)`. If the tuple is already in this format, the function does nothing.