### PR TITLE
correlation output to 3 digits under decimal point

### DIFF
--- a/pcmdi_metrics/mean_climate/lib/compute_metrics.py
+++ b/pcmdi_metrics/mean_climate/lib/compute_metrics.py
@@ -197,7 +197,7 @@ def compute_metrics(Var, dm, do, debug=False, time_dim_sync=False):
         metrics_dictionary["bias_xy"][sea] = format(bias_sea, sig_digits)
         metrics_dictionary["rms_xy"][sea] = format(rms_sea, sig_digits)
         metrics_dictionary["rmsc_xy"][sea] = format(rmsc_sea, sig_digits)
-        metrics_dictionary["cor_xy"][sea] = format(cor_sea, ".2f")
+        metrics_dictionary["cor_xy"][sea] = format(cor_sea, sig_digits)
         metrics_dictionary["mae_xy"][sea] = format(mae_sea, sig_digits)
         metrics_dictionary["std-obs_xy"][sea] = format(stdObs_xy_sea, sig_digits)
         metrics_dictionary["std_xy"][sea] = format(std_xy_sea, sig_digits)


### PR DESCRIPTION
For mean climate correlation variable, increased from 2 digits to 3 digits.