### PR TITLE
Bug fix for the mean_climate and varibility_mode drivers 

### DIFF
--- a/pcmdi_metrics/mean_climate/mean_climate_driver.py
+++ b/pcmdi_metrics/mean_climate/mean_climate_driver.py
@@ -167,7 +167,9 @@ for var in vars:
     result_dict["Variable"] = dict()
     result_dict["Variable"]["id"] = varname
     if level is not None:
-        result_dict["Variable"]["level"] = level * 100  # hPa to Pa
+        result_dict["Variable"][
+            "level"
+        ] = level  # SZhang: should not "* 100" here  # hPa to Pa
 
     result_dict["References"] = dict()
 

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -142,8 +142,8 @@ def subset_time(
         eyear = int(eyear)
 
     # First trimming
-    time1 = f"{syear}-01-01 00:00:00"
-    time2 = f"{eyear}-12-{eday} 23:59:59"
+    time1 = f"{syear:04d}-01-01 00:00:00"
+    time2 = f"{eyear:04d}-12-{eday:02d} 23:59:59"
     ds = select_subset(ds, time=(time1, time2))
 
     # Check available time window and adjust again if needed
@@ -170,8 +170,8 @@ def subset_time(
 
     # Second trimming
     if adjust_time_length:
-        time1 = f"{data_syear}-01-01 00:00:00"
-        time2 = f"{data_eyear}-12-{eday} 23:59:59"
+        time1 = f"{data_syear:04d}-01-01 00:00:00"
+        time2 = f"{data_eyear:04d}-12-{eday:02d} 23:59:59"
         ds = select_subset(ds, time=(time1, time2))
 
     return ds


### PR DESCRIPTION
Hi Jiwoo,

I submit this pull request to propose some solutions for the recent bug found in my run cases: 

1. the first small bug fix is related to the issue as I mentioned in https://github.com/PCMDI/pcmdi_metrics/issues/1128, i.e. the unit conversion for pressure level data and its related calculation in mean climate driver 

2. the second small bug fix is to address the issue I mentioned in your e-mail, i.e. the analysis for the model simulations that started from year 0 such as piControl simulations.   From my tests, the piControl simulation can be processed without issues by fixing the following two places: 

- add an explicit conversion of year to 4-digts in pcmdi_metrics/variability_mode/lib/lib_variability_mode.py, which is included in this pull request for the PCMDI package. 

- meanwhile, adjustments in the external library, i.e. XCDAT are also needed, you can see the bug report I submitted at https://github.com/xCDAT/xcdat/issues/695

Please take a look and see if they provide useful hints for you to develop a better solution in the PCMDI package. 

