### PR TITLE
run ci regardless PR in draft or ready

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -6,7 +6,6 @@ on:
 
   pull_request:
     branches: [main]
-    types: [ready_for_review]
 
   workflow_dispatch:
 
@@ -16,7 +15,6 @@ env:
 
 jobs:
   check-jobs-to-skip:
-    if: ${{ github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -29,7 +27,7 @@ jobs:
 
   pre-commit-hooks:
     needs: check-jobs-to-skip
-    if: ${{ (needs.check-jobs-to-skip.outputs.should_skip != 'true' || github.event_name == 'push') && github.event.pull_request.draft != true }}
+    if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }} || ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,7 +44,7 @@ jobs:
 
   build:
     needs: check-jobs-to-skip
-    if: ${{ (needs.check-jobs-to-skip.outputs.should_skip != 'true' || github.event_name == 'push') && github.event.pull_request.draft != true }}
+    if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }} || ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -100,7 +98,7 @@ jobs:
 
 
   publish-docs:
-    if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.event.pull_request.draft != true }}
+    if: ${{ github.event_name == 'push' }} ||  ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # Configuration file for `pre-commit` tool.
 # Source: https://pre-commit.com/#pre-commit-configyaml---top-level
 exclude: "docs|node_modules|migrations|.git|.tox|README.md|sample_setups/(external-setups|jsons)|tests/deprecated"
-default_stages: [commit]
+default_stages: [pre-commit]
 fail_fast: true
 
 repos:


### PR DESCRIPTION
I am cancelling the changes made in #1160 to turn Github Action CI back on for all PR status, so any error can be detected from the early stage of the PR.