### PR TITLE
Disable dask chunk for MoV

### DIFF
--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -78,7 +78,6 @@ def eof_analysis_get_variance_mode(
     grid_area = calculate_grid_area(ds)
     area_weights = calculate_area_weights(grid_area)
     da = ds[data_var]
-    debug_print("Lib-EOF: Eof start", debug)
     solver = Eof(da, weights=area_weights)
     debug_print("Lib-EOF: eof", debug)
 

--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -78,6 +78,7 @@ def eof_analysis_get_variance_mode(
     grid_area = calculate_grid_area(ds)
     area_weights = calculate_area_weights(grid_area)
     da = ds[data_var]
+    debug_print("Lib-EOF: Eof start", debug)
     solver = Eof(da, weights=area_weights)
     debug_print("Lib-EOF: eof", debug)
 

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -94,7 +94,7 @@ def read_data_in(
     debug: bool = False,
 ) -> xr.Dataset:
     # Open data file
-    ds = xcdat_open(path)
+    ds = xcdat_open(path, chunks=None)
 
     # Data QC check -- time axis check
     check_monthly_time_axis(ds)


### PR DESCRIPTION
To avoid conflict between `Eof` and `dask_chunks`, `chunks=None` is used for `xcdat_open` for modes of variability metrics. 