### PR TITLE
Replace NaN with None in CMEC JSON

### DIFF
--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -470,9 +470,17 @@ class Base(cdp.cdp_io.CDPIO, StringConstructor):
                         # process sub-dictionary
                         tmp_dict = recursive_replace(new_dict[key], extra_fields)
                         new_dict[key] = tmp_dict
-                    # convert string metrics to float
+                    # convert string metrics to float or None
                     if isinstance(new_dict[key], str):
-                        new_dict[key] = float(new_dict[key])
+                        if new_dict[key] == "NaN":
+                            new_dict[key] = None
+                        else:
+                            new_dict[key] = float(new_dict[key])
+                    # convert NaN to None
+                    elif not isinstance(new_dict[key], dict):
+                        if not isinstance(new_dict[key], list):
+                            if numpy.isnan(new_dict[key]):
+                                new_dict[key] = None
             return new_dict
 
         extra_fields = [


### PR DESCRIPTION
Replace instances of "NaN" in the RESULTS object with None/null. This does not check inside lists - any values inside lists will be skipped.