### PR TITLE
Option to turn off conda use in the code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     # General file formatters
     # =======================
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
+      rev: v5.0.0
       hooks:
           - id: trailing-whitespace
             args: [--markdown-linebreak-ext=md]
@@ -25,7 +25,7 @@ repos:
           - id: black
 
     - repo: https://github.com/timothycrosley/isort
-      rev: 5.13.2
+      rev: 6.0.1
       hooks:
           - id: isort
             args: ["--honor-noqa"]

--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -352,6 +352,7 @@ class Base(cdp.cdp_io.CDPIO, StringConstructor):
         include_YAML=False,
         include_history=False,
         include_script=False,
+        include_provenance=True,
         *args,
         **kwargs,
     ):
@@ -389,20 +390,26 @@ class Base(cdp.cdp_io.CDPIO, StringConstructor):
                 f = open(file_name)
                 out_dict = json.load(f)
             else:
-                out_dict = OrderedDict({"provenance": generateProvenance()})
+                if include_provenance:
+                    out_dict = OrderedDict({"provenance": generateProvenance()})
+                else:
+                    out_dict = OrderedDict({"provenance": dict()})
             f = open(file_name, "w")
             update_dict(out_dict, data)
-            if "yaml" in out_dict["provenance"]["conda"]:
-                if include_YAML:
-                    out_dict["YAML"] = out_dict["provenance"]["conda"]["yaml"]
-                del out_dict["provenance"]["conda"]["yaml"]
+            if "conda" in out_dict["provenance"]:
+                if "yaml" in out_dict["provenance"]["conda"]:
+                    if include_YAML:
+                        out_dict["YAML"] = out_dict["provenance"]["conda"]["yaml"]
+                    del out_dict["provenance"]["conda"]["yaml"]
 
             if not include_script:
                 if "script" in out_dict["provenance"].keys():
                     del out_dict["provenance"]["script"]
+
             if not include_history:
                 if "history" in out_dict["provenance"].keys():
                     del out_dict["provenance"]["history"]
+
             json.dump(out_dict, f, cls=CDMSDomainsEncoder, *args, **kwargs)
             f.close()
 

--- a/pcmdi_metrics/variability_mode/lib/argparse_functions.py
+++ b/pcmdi_metrics/variability_mode/lib/argparse_functions.py
@@ -201,6 +201,20 @@ def AddParserArgument(P):
         help="Option for update existing JSON file: True (i.e., update) (default) / False (i.e., overwrite)",
     )
     P.add_argument(
+        "--provenance",
+        dest="provenance",
+        action="store_true",
+        default=True,
+        help="Save provenance in output JSON",
+    )
+    P.add_argument(
+        "--no_provenance",
+        dest="provenance",
+        action="store_false",
+        default=False,
+        help="Option to not save provenance in output JSON",
+    )
+    P.add_argument(
         "--cmec",
         dest="cmec",
         action="store_true",

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -315,6 +315,7 @@ def variability_metrics_to_json(
     model: str = None,
     run: str = None,
     cmec_flag: bool = False,
+    include_provenance: bool = True,
 ):
     # Open JSON
     JSON = pcmdi_metrics.io.base.Base(outdir, json_filename)
@@ -346,6 +347,7 @@ def variability_metrics_to_json(
         sort_keys=True,
         indent=4,
         separators=(",", ": "),
+        include_provenance=include_provenance,
     )
     if cmec_flag:
         print("Writing cmec file")

--- a/pcmdi_metrics/variability_mode/variability_modes_driver.py
+++ b/pcmdi_metrics/variability_mode/variability_modes_driver.py
@@ -89,10 +89,12 @@ ConvEOF = param.ConvEOF  # Conduct conventional EOF analysis
 EofScaling = param.EofScaling  # If True, consider EOF with unit variance
 RmDomainMean = param.RemoveDomainMean  # If True, remove Domain Mean of each time step
 LandMask = param.landmask  # If True, maskout land region thus consider only over ocean
+provenance = param.provenance
 
 print("EofScaling:", EofScaling)
 print("RmDomainMean:", RmDomainMean)
 print("LandMask:", LandMask)
+print("provenance:", provenance)
 
 nc_out_obs = param.nc_out_obs  # Record NetCDF output
 plot_obs = param.plot_obs  # Generate plots
@@ -1075,6 +1077,7 @@ for model in models:
             # =================================================================
             # Dictionary to JSON: individual JSON during model_realization loop
             # -----------------------------------------------------------------
+            debug_print("json (individual) writing start", debug)
             json_filename_tmp = f"var_mode_{mode}_EOF{eofn_mod}_stat_{mip}_{exp}_{fq}_{realm}_{model}_{run}_{msyear}-{meyear}"
 
             variability_metrics_to_json(
@@ -1084,7 +1087,9 @@ for model in models:
                 model=model,
                 run=run,
                 cmec_flag=cmec,
+                include_provenance=provenance,
             )
+            debug_print("json (individual) writing done", debug)
 
         except Exception as err:
             if debug:
@@ -1096,10 +1101,12 @@ for model in models:
 # Dictionary to JSON: collective JSON at the end of model_realization loop
 # ------------------------------------------------------------------------
 if not parallel and (len(models) > 1):
+    debug_print("json (collective) writing start", debug)
     json_filename_all = f"var_mode_{mode}_EOF{eofn_mod}_stat_{mip}_{exp}_{fq}_{realm}_allModels_allRuns_{msyear}-{meyear}"
     variability_metrics_to_json(
         dir_paths["metrics_results"], json_filename_all, result_dict, cmec_flag=cmec
     )
+    debug_print("json (collective) writing done", debug)
 
 if not debug:
     sys.exit(0)


### PR DESCRIPTION
In the current setup, provenance generation for JSON output uses `conda` explicitly as a part of the code. Option added to MoV driver and base class to disable this capability to avoid use `conda`, as it has conflict in the PMP's REF implementation. Default is still include provenance, but it can now be turned off by adding `--no_provenance` tag in the command line. 