### PR TITLE
Update __init__.py

### DIFF
--- a/pcmdi_metrics/enso/lib/__init__.py
+++ b/pcmdi_metrics/enso/lib/__init__.py
@@ -11,3 +11,4 @@ from .enso_lib import (  # noqa
 
 from .summary_plot_lib.EnsoPlotLib import plot_param
 from .summary_plot_lib.plot import enso_portrait_plot
+from .summary_plot_lib.plot import json_dict_to_numpy_array_list

--- a/pcmdi_metrics/enso/lib/__init__.py
+++ b/pcmdi_metrics/enso/lib/__init__.py
@@ -10,5 +10,4 @@ from .enso_lib import (  # noqa
 )
 
 from .summary_plot_lib.EnsoPlotLib import plot_param
-from .summary_plot_lib.plot import enso_portrait_plot
-from .summary_plot_lib.plot import json_dict_to_numpy_array_list
+from .summary_plot_lib.plot import enso_portrait_plot, json_dict_to_numpy_array_list


### PR DESCRIPTION
The ENSO ref_info_dict is retrieved from json_dict_to_numpy_array_list ([here](https://github.com/PCMDI/pcmdi_metrics/blob/cdd2d2918ddd14fc3995907f93b51023d7dae9e7/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py#L104), where the function itself is defined [here](https://github.com/PCMDI/pcmdi_metrics/blob/cdd2d2918ddd14fc3995907f93b51023d7dae9e7/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py#L155) in the same file), under the enso_portrait_plot function. 

To use this function directly the function was registered at __init__.py ([here](https://github.com/PCMDI/pcmdi_metrics/blob/main/pcmdi_metrics/enso/lib/__init__.py)) so it can be importable as like below.

```
from pcmdi_metrics.enso.lib import json_dict_to_numpy_array_list
```