### PR TITLE
Allow users to specify a specific conda location

### DIFF
--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -37,11 +37,28 @@ try:
 except Exception:
     basestring = str
 
-CONDA = os.environ.get("CONDA_PYTHON_EXE", "")
-if CONDA != "":
-    CONDA = os.path.join(os.path.dirname(CONDA), "conda")
-else:
-    CONDA = "conda"
+
+def _determine_conda():
+    """
+    Attempt to determine the path to the conda executable
+    """
+    # Begin by checking if user has forced a specific conda executable
+    override_conda_exe = os.environ.get("PCMDI_CONDA_EXE")
+    if override_conda_exe:
+        return override_conda_exe
+
+    # Next check if we are in a conda environment
+    conda_python_exe = os.environ.get("CONDA_PYTHON_EXE", "")
+    if conda_python_exe != "":
+        conda_exe = os.path.join(os.path.dirname(conda_python_exe), "conda")
+    else:
+        # Fall back to assuming conda is in the PATH
+        conda_exe = "conda"
+
+    return conda_exe
+
+
+CONDA = _determine_conda()
 
 
 def download_sample_data_files(files_md5, path):


### PR DESCRIPTION
Support the use of conda alternatives such as micromamba by using an environment variable.

I'm not aware of a consistent way of determining the appropriate executable in all cases.