### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     # General file formatters
     # =======================
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
+      rev: v6.0.0
       hooks:
           - id: trailing-whitespace
             args: [--markdown-linebreak-ext=md]
@@ -20,7 +20,7 @@ repos:
     # Python code formatters
     # =======================
     - repo: https://github.com/psf/black
-      rev: 23.3.0
+      rev: 25.1.0
       hooks:
           - id: black
 
@@ -34,7 +34,7 @@ repos:
     # Python linting
     # =======================
     - repo: https://github.com/pycqa/flake8
-      rev: 7.0.0
+      rev: 7.3.0
       hooks:
           - id: flake8
             args: ["--config=setup.cfg"]

--- a/cmec/diurnal_cycle/diurnal_cycle_output.py
+++ b/cmec/diurnal_cycle/diurnal_cycle_output.py
@@ -4,6 +4,7 @@ Create and populate the output.json metadata file that
 documents the cmec-driver pipeline outputs for the
 Diurnal metrics.
 """
+
 import json
 import os
 

--- a/cmec/mean_climate/mean_climate_output.py
+++ b/cmec/mean_climate/mean_climate_output.py
@@ -4,6 +4,7 @@ Create and populate the output.json metadata file that
 documents the cmec-driver pipeline outputs for the
 Mean Climate metrics.
 """
+
 import json
 import os
 

--- a/cmec/monsoon_sperber/monsoon_sperber_output.py
+++ b/cmec/monsoon_sperber/monsoon_sperber_output.py
@@ -4,6 +4,7 @@ Create and populate the output.json metadata file that
 documents the cmec-driver pipeline outputs for the
 Monsoon (Sperber) metrics.
 """
+
 import json
 import os
 

--- a/cmec/monsoon_wang/monsoon_wang_output.py
+++ b/cmec/monsoon_wang/monsoon_wang_output.py
@@ -4,6 +4,7 @@ Create and populate the output.json metadata file that
 documents the cmec-driver pipeline outputs for the
 Monsoon (Wang) metrics.
 """
+
 import glob
 import json
 import os

--- a/cmec/mov/mov_output.py
+++ b/cmec/mov/mov_output.py
@@ -4,6 +4,7 @@ Create and populate the output.json metadata file that
 documents the cmec-driver pipeline outputs for the
 Modes of Variability metrics.
 """
+
 import json
 import os
 

--- a/pcmdi_metrics/cloud_feedback/cloud_feedback_driver.py
+++ b/pcmdi_metrics/cloud_feedback/cloud_feedback_driver.py
@@ -193,9 +193,9 @@ output_dict["RESULTS"][model][variant]["assessed_cloud_feedback"][
 output_dict["RESULTS"][model][variant]["assessed_cloud_feedback"][
     "implied_unassessed"
 ] = assessed_cld_fbk[6]
-output_dict["RESULTS"][model][variant]["assessed_cloud_feedback"][
-    "sum_of_assessed"
-] = assessed_cld_fbk[7]
+output_dict["RESULTS"][model][variant]["assessed_cloud_feedback"]["sum_of_assessed"] = (
+    assessed_cld_fbk[7]
+)
 output_dict["RESULTS"][model][variant]["assessed_cloud_feedback"][
     "total_cloud_feedback"
 ] = assessed_cld_fbk[8]

--- a/pcmdi_metrics/diurnal/scripts/savg_fourier.py
+++ b/pcmdi_metrics/diurnal/scripts/savg_fourier.py
@@ -249,9 +249,9 @@ def main():
     egg_pth = resources.resource_path()
     disclaimer = open(os.path.join(egg_pth, "disclaimer.txt")).read()
     metrics_dictionary["DISCLAIMER"] = disclaimer
-    metrics_dictionary[
-        "REFERENCE"
-    ] = "The statistics in this file are based on Covey et al., J Climate 2016"
+    metrics_dictionary["REFERENCE"] = (
+        "The statistics in this file are based on Covey et al., J Climate 2016"
+    )
 
     # Accumulate output from each model (or observed) data source in the
     # Python dictionary.

--- a/pcmdi_metrics/mean_climate/deprecated/lib/outputmetrics.py
+++ b/pcmdi_metrics/mean_climate/deprecated/lib/outputmetrics.py
@@ -219,9 +219,9 @@ class OutputMetrics(object):
                         {"custom": self.parameter.compute_custom_metrics.__doc__}
                     )
 
-            parameter_realization[
-                self.get_region_name_from_region(ref.region)
-            ] = collections.OrderedDict((k, pr_rgn[k]) for k in sorted(pr_rgn.keys()))
+            parameter_realization[self.get_region_name_from_region(ref.region)] = (
+                collections.OrderedDict((k, pr_rgn[k]) for k in sorted(pr_rgn.keys()))
+            )
 
             self.metrics_dictionary["RESULTS"][test.obs_or_model][ref.obs_or_model][
                 self.parameter.realization
@@ -319,9 +319,9 @@ class OutputMetrics(object):
             self.metrics_dictionary["RESULTS"][test.obs_or_model][
                 "InputRegionFileName"
             ] = self.sftlf[test.obs_or_model]["filename"]
-            self.metrics_dictionary["RESULTS"][test.obs_or_model][
-                "InputRegionMD5"
-            ] = self.sftlf[test.obs_or_model]["md5"]
+            self.metrics_dictionary["RESULTS"][test.obs_or_model]["InputRegionMD5"] = (
+                self.sftlf[test.obs_or_model]["md5"]
+            )
 
     def output_interpolated_model_climatologies(self, test, test_data):
         """Save the netCDF file."""

--- a/pcmdi_metrics/mean_climate/mean_climate_driver.py
+++ b/pcmdi_metrics/mean_climate/mean_climate_driver.py
@@ -478,14 +478,14 @@ for var in vars:
 
                             # compute metrics
                             print("compute metrics start")
-                            result_dict["RESULTS"][model][ref][run][
-                                region
-                            ] = compute_metrics(
-                                varname,
-                                ds_test_dict[region],
-                                ds_ref_dict[region],
-                                debug=debug,
-                                time_dim_sync=time_dim_sync,
+                            result_dict["RESULTS"][model][ref][run][region] = (
+                                compute_metrics(
+                                    varname,
+                                    ds_test_dict[region],
+                                    ds_ref_dict[region],
+                                    debug=debug,
+                                    time_dim_sync=time_dim_sync,
+                                )
                             )
 
                             # write individual JSON

--- a/pcmdi_metrics/misc/scripts/parallel_submitter.py
+++ b/pcmdi_metrics/misc/scripts/parallel_submitter.py
@@ -75,9 +75,10 @@ def parallel_submitter(
             log_file = os.path.join(log_dir, logfilename_list[index])
 
         # SUBMIT PROCESS
-        with open(log_file + "_stdout.txt", "wb") as out, open(
-            log_file + "_stderr.txt", "wb"
-        ) as err:
+        with (
+            open(log_file + "_stdout.txt", "wb") as out,
+            open(log_file + "_stderr.txt", "wb") as err,
+        ):
             p = subprocess.Popen(process.split(" "), stdout=out, stderr=err)
             processes.append(p)
 

--- a/pcmdi_metrics/monsoon_sperber/lib/calc_metrics.py
+++ b/pcmdi_metrics/monsoon_sperber/lib/calc_metrics.py
@@ -1,4 +1,4 @@
-""" Calculate metrics based on Sperber and Annamalai 2014 Clim. Dyn.,
+"""Calculate metrics based on Sperber and Annamalai 2014 Clim. Dyn.,
 which are:
 - onset pentad index: when fractional accumulation hit 20%
 - decay pentad index: when fractional accumulation hit 80%

--- a/pcmdi_metrics/monsoon_wang/lib/monsoon_precip_index_fncs.py
+++ b/pcmdi_metrics/monsoon_wang/lib/monsoon_precip_index_fncs.py
@@ -231,9 +231,9 @@ def save_to_netcdf_with_attributes(ds_new, ds_org, org_path, nout_mpi_obs):
         if attr not in ["history", "source"]:
             ds_new.attrs[attr] = ds_org.attrs[attr]
     # Add new global attributes
-    ds_new.attrs[
-        "history"
-    ] = f"Created by PMP {pcmdi_metrics.__version__} on {datetime.datetime.now()}"
+    ds_new.attrs["history"] = (
+        f"Created by PMP {pcmdi_metrics.__version__} on {datetime.datetime.now()}"
+    )
     ds_new.attrs["source"] = f"Created from {org_path} by PMP"
     # Save to netcdf
     ds_new.to_netcdf(nout_mpi_obs)

--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -118,9 +118,9 @@ def eof_analysis_get_variance_mode(
         eof_Nth.attrs["variable"] = data_var
         eof_Nth.attrs["eof_mode"] = n + 1
         frac_Nth.attrs["units"] = "ratio"
-        pc_Nth.attrs[
-            "comment"
-        ] = f"Non-scaled time series for principal component of {eofn}th variance mode"
+        pc_Nth.attrs["comment"] = (
+            f"Non-scaled time series for principal component of {eofn}th variance mode"
+        )
         pc_Nth.attrs["variable"] = data_var
         pc_Nth.attrs["eof_mode"] = n + 1
 
@@ -278,9 +278,9 @@ def linear_regression_on_globe_for_teleconnection(
 
     eof_lr.attrs["variable"] = data_var
     eof_lr.attrs["description"] = "linear regression on global field for teleconnection"
-    eof_lr.attrs[
-        "comment"
-    ] = "Reconstructed EOF pattern with teleconnection considerations"
+    eof_lr.attrs["comment"] = (
+        "Reconstructed EOF pattern with teleconnection considerations"
+    )
     if "eof_mode" in pc.attrs:
         eof_lr.attrs["eof_mode"] = pc.attrs["eof_mode"]
 

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -136,9 +136,9 @@ def write_nc_output(
         }
     )
     # Add global attributes
-    ds.attrs[
-        "title"
-    ] = "PCMDI Metrics Package Extratropical Modes of Variability diagnostics"
+    ds.attrs["title"] = (
+        "PCMDI Metrics Package Extratropical Modes of Variability diagnostics"
+    )
     ds.attrs["author"] = "PCMDI"
     ds.attrs["contact"] = "pcmdi-metrics@llnl.gov"
     ds.attrs["creation_date"] = strftime("%Y-%m-%d %H:%M:%S", gmtime())

--- a/pcmdi_metrics/variability_mode/param/myParam_demo_NAM.py
+++ b/pcmdi_metrics/variability_mode/param/myParam_demo_NAM.py
@@ -35,7 +35,7 @@ debug = False
 reference_data_name = "NOAA-CIRES_20CR"
 reference_data_path = os.path.join(
     "/p/user_pub/PCMDIobs/obs4MIPs/NOAA-ESRL-PSD/20CR/mon/psl/gn/latest",
-    "psl_mon_20CR_PCMDI_gn_187101-201212.nc"
+    "psl_mon_20CR_PCMDI_gn_187101-201212.nc",
     # "/p/user_pub/PCMDIobs/PCMDIobs2/atmos/mon/psl/20CR/gn/v20200707",
     # "psl_mon_20CR_BE_gn_v20200707_187101-201212.nc",
 )

--- a/pcmdi_metrics/variability_mode/param/myParam_pcmdi_NAM.py
+++ b/pcmdi_metrics/variability_mode/param/myParam_pcmdi_NAM.py
@@ -42,7 +42,7 @@ debug = False
 reference_data_name = "NOAA-CIRES_20CR"
 reference_data_path = os.path.join(
     "/p/user_pub/PCMDIobs/obs4MIPs/NOAA-ESRL-PSD/20CR/mon/psl/gn/latest",
-    "psl_mon_20CR_PCMDI_gn_187101-201212.nc"
+    "psl_mon_20CR_PCMDI_gn_187101-201212.nc",
     # "/p/user_pub/PCMDIobs/PCMDIobs2/atmos/mon/psl/20CR/gn/v20200707",
     # "psl_mon_20CR_BE_gn_v20200707_187101-201212.nc",
 )

--- a/pcmdi_metrics/variability_mode/param/myParam_pcmdi_SAM.py
+++ b/pcmdi_metrics/variability_mode/param/myParam_pcmdi_SAM.py
@@ -42,7 +42,7 @@ debug = False
 reference_data_name = "NOAA-CIRES_20CR"
 reference_data_path = os.path.join(
     "/p/user_pub/PCMDIobs/obs4MIPs/NOAA-ESRL-PSD/20CR/mon/psl/gn/latest",
-    "psl_mon_20CR_PCMDI_gn_187101-201212.nc"
+    "psl_mon_20CR_PCMDI_gn_187101-201212.nc",
     # "/p/user_pub/PCMDIobs/PCMDIobs2/atmos/mon/psl/20CR/gn/v20200707",
     # "psl_mon_20CR_BE_gn_v20200707_187101-201212.nc",
 )

--- a/pcmdi_metrics/variability_mode/variability_modes_driver.py
+++ b/pcmdi_metrics/variability_mode/variability_modes_driver.py
@@ -643,10 +643,10 @@ for model in models:
 
                     # QC
                     if var == "ts":
-                        model_timeseries_season_regrid[
-                            var
-                        ] = model_timeseries_season_regrid[var].where(
-                            model_timeseries_season_regrid[var] < 1e10
+                        model_timeseries_season_regrid[var] = (
+                            model_timeseries_season_regrid[var].where(
+                                model_timeseries_season_regrid[var] < 1e10
+                            )
                         )
 
                     # crop to subdomain
@@ -1035,9 +1035,9 @@ for model in models:
                     dict_head["best_matching_model_eofs__rms"] = best_matching_eofs_rms
                     dict_head["best_matching_model_eofs__cor"] = best_matching_eofs_cor
                     if CBF:
-                        dict_head[
-                            "best_matching_model_eofs__tcor_cbf_vs_eof_pc"
-                        ] = best_matching_eofs_tcor
+                        dict_head["best_matching_model_eofs__tcor_cbf_vs_eof_pc"] = (
+                            best_matching_eofs_tcor
+                        )
 
                     debug_print("conventional eof end", debug)
 

--- a/pcmdi_metrics/viewer/pmp_output_viewer.py
+++ b/pcmdi_metrics/viewer/pmp_output_viewer.py
@@ -988,9 +988,11 @@ def create_mean_clim_divedown_df(mean_clim_dict, mips, assets_path):
             lambda row: (
                 f"{img_url_head}/{row['MIP']}/{row['Experiment']}/clim/v20210811/{row['Variable']}/{row['Region']}/{row['Variable']}_{row['MIP']}_{row['Experiment']}_{row['Model']}_{s.lower()}_global.png"
                 if row["MIP"] == "cmip6"
-                else f"{img_url_head}/{row['MIP']}/{row['Experiment']}/clim/v20200505/{row['Variable']}/{row['Variable']}_{row['MIP']}_{row['Experiment']}_{row['Model']}_{s.lower()}.png"
-                if row["MIP"] == "cmip5"
-                else None
+                else (
+                    f"{img_url_head}/{row['MIP']}/{row['Experiment']}/clim/v20200505/{row['Variable']}/{row['Variable']}_{row['MIP']}_{row['Experiment']}_{row['Model']}_{s.lower()}.png"
+                    if row["MIP"] == "cmip5"
+                    else None
+                )
             ),
             axis=1,
         )
@@ -1122,19 +1124,21 @@ def create_mov_df(mov_dict, mips):
                 "var_mode_NAM_EOF1_stat_cmip6_historical_mo_atm_allModels_allRuns_1900-2005"
             ]["RESULTS"][row["Model"]]
             is not None
-            else ", ".join(
-                list(
-                    results_dict[row["MIP"]]["variability_modes"][
-                        "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
-                    ]["RESULTS"][row["Model"]].keys()
+            else (
+                ", ".join(
+                    list(
+                        results_dict[row["MIP"]]["variability_modes"][
+                            "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
+                        ]["RESULTS"][row["Model"]].keys()
+                    )
                 )
+                if row["MIP"] == "cmip5"
+                and results_dict[row["MIP"]]["variability_modes"][
+                    "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
+                ]["RESULTS"][row["Model"]]
+                is not None
+                else None
             )
-            if row["MIP"] == "cmip5"
-            and results_dict[row["MIP"]]["variability_modes"][
-                "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
-            ]["RESULTS"][row["Model"]]
-            is not None
-            else None
         ),
         axis=1,
     )
@@ -1156,22 +1160,24 @@ def create_mov_df(mov_dict, mips):
                 "var_mode_NAM_EOF1_stat_cmip6_historical_mo_atm_allModels_allRuns_1900-2005"
             ]["RESULTS"][row["Model"]]
             is not None
-            else ", ".join(
-                list(
-                    ["1900-2005"]
-                    * len(
-                        results_dict[row["MIP"]]["variability_modes"][
-                            "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
-                        ]["RESULTS"][row["Model"]].keys()
+            else (
+                ", ".join(
+                    list(
+                        ["1900-2005"]
+                        * len(
+                            results_dict[row["MIP"]]["variability_modes"][
+                                "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
+                            ]["RESULTS"][row["Model"]].keys()
+                        )
                     )
                 )
+                if row["MIP"] == "cmip5"
+                and results_dict[row["MIP"]]["variability_modes"][
+                    "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
+                ]["RESULTS"][row["Model"]]
+                is not None
+                else None
             )
-            if row["MIP"] == "cmip5"
-            and results_dict[row["MIP"]]["variability_modes"][
-                "var_mode_NAM_EOF1_stat_cmip5_historical_mo_atm_allModels_allRuns_1900-2005"
-            ]["RESULTS"][row["Model"]]
-            is not None
-            else None
         ),
         axis=1,
     )
@@ -1180,9 +1186,11 @@ def create_mov_df(mov_dict, mips):
         lambda row: (
             f"{url_head}mip={row['MIP']}&exp=historical&ver=v20220825&mode={row['Mode']}&ref={row['Reference']}&var={row['Variable']}&method={row['Method']}&season={row['Season']}&model={row['Model']}&runs={row['Runs']}&periods={row['Periods']}"
             if row["MIP"] == "cmip6"
-            else f"{url_head}mip={row['MIP']}&exp=historical&ver=v20200116&mode={row['Mode']}&ref={row['Reference']}&var={row['Variable']}&method={row['Method']}&season={row['Season']}&model={row['Model']}&runs={row['Runs']}&periods={row['Periods']}"
-            if row["MIP"] == "cmip5"
-            else None
+            else (
+                f"{url_head}mip={row['MIP']}&exp=historical&ver=v20200116&mode={row['Mode']}&ref={row['Reference']}&var={row['Variable']}&method={row['Method']}&season={row['Season']}&model={row['Model']}&runs={row['Runs']}&periods={row['Periods']}"
+                if row["MIP"] == "cmip5"
+                else None
+            )
         ),
         axis=1,
     )


### PR DESCRIPTION
This PR updates the versions of black and flake8 used for linting.  A newer version of black is needed for python >=3.12 support.

It then includes changes required by the new black for all files in both `pcmdi_metrics` and `cmec`.