### PR TITLE
Switch from pkg_resources (deprecated) to importlib

### DIFF
--- a/pcmdi_metrics/resources.py
+++ b/pcmdi_metrics/resources.py
@@ -16,7 +16,7 @@ def resource_path():
         # Use importlib.metadata to locate data-files installed with the
         # distribution
         res_path = str(dist.locate_file("share/pmp"))
-    except Exception:
+    except metadata.PackageNotFoundError:
         res_path = os.path.join(os.getcwd(), "share", "pmp")
 
     # Should never fail this

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -21,7 +21,9 @@ def test_conda_env(tmpdir):
 @mock.patch("importlib.metadata.distribution")
 def test_conda_env_no_exist(distribution, getcwd, tmpdir):
     # Fix issue when tests are ran against an installed package
-    distribution.side_effect = Exception()
+    import importlib.metadata as _md
+
+    distribution.side_effect = _md.PackageNotFoundError
 
     conda_prefix = os.path.join(tmpdir, "conda")
 


### PR DESCRIPTION
This pull request updates the way package resources are located in the `pcmdi_metrics` package by replacing the deprecated `pkg_resources` with `importlib.metadata`. The changes affect both the resource location logic and related tests, ensuring compatibility with modern Python packaging practices.

Migration from `pkg_resources` to `importlib.metadata`:

* Updated `pcmdi_metrics/resources.py` to use `importlib.metadata` instead of `pkg_resources` for locating package data files, specifically replacing `pkg_resources.resource_filename` with `metadata.distribution(...).locate_file(...)`. [[1]](diffhunk://#diff-a79a22765f9c6645745fb88c69efbdd3b6a749ce8f03f48577b01ffcea257c8bL2-R2) [[2]](diffhunk://#diff-a79a22765f9c6645745fb88c69efbdd3b6a749ce8f03f48577b01ffcea257c8bL16-R18)

Test updates for new resource location logic:

* Refactored tests in `tests/test_resources.py` to mock `importlib.metadata.distribution` instead of `pkg_resources.resource_filename` and `pkg_resources.Requirement.parse`, including the use of a dummy distribution object for resource location. [[1]](diffhunk://#diff-21c4e9455aec319bbca64714eed19137dc3113ec5e1325ee5a6d937dad76e71eL21-R24) [[2]](diffhunk://#diff-21c4e9455aec319bbca64714eed19137dc3113ec5e1325ee5a6d937dad76e71eL40-R46)