### PR TITLE
MoV update to run smoothly with diverse datasets

### DIFF
--- a/pcmdi_metrics/variability_mode/lib/adjust_timeseries.py
+++ b/pcmdi_metrics/variability_mode/lib/adjust_timeseries.py
@@ -1,3 +1,4 @@
+import copy
 import xarray as xr
 
 from pcmdi_metrics.io import (
@@ -134,7 +135,7 @@ def get_residual_timeseries(
         raise TypeError(
             "The first parameter of get_residual_timeseries must be an xarray Dataset"
         )
-    ds_residual = ds_anomaly.copy()
+    ds_residual = copy.deepcopy(ds_anomaly)
     if RmDomainMean:
         # Get domain mean
         ds_anomaly_region = region_subset(

--- a/pcmdi_metrics/variability_mode/lib/adjust_timeseries.py
+++ b/pcmdi_metrics/variability_mode/lib/adjust_timeseries.py
@@ -1,4 +1,5 @@
 import copy
+
 import xarray as xr
 
 from pcmdi_metrics.io import (

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -209,7 +209,11 @@ def read_data_in(
         data_timeseries = adjust_units(data_timeseries, UnitsAdjust)
 
     # Masking
-    if (var_in_data.lower() in ["ts", "sst"]) or (var_to_consider.lower() in ["ts", "sst"]) and LandMask:
+    if (
+        (var_in_data.lower() in ["ts", "sst"])
+        or (var_to_consider.lower() in ["ts", "sst"])
+        and LandMask
+    ):
         # Replace temperature below -1.8 C to -1.8 C (sea ice)
         data_timeseries = sea_ice_adjust(data_timeseries)
 

--- a/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
+++ b/pcmdi_metrics/variability_mode/lib/lib_variability_mode.py
@@ -209,7 +209,7 @@ def read_data_in(
         data_timeseries = adjust_units(data_timeseries, UnitsAdjust)
 
     # Masking
-    if var_to_consider == "ts" and LandMask:
+    if (var_in_data.lower() in ["ts", "sst"]) or (var_to_consider.lower() in ["ts", "sst"]) and LandMask:
         # Replace temperature below -1.8 C to -1.8 C (sea ice)
         data_timeseries = sea_ice_adjust(data_timeseries)
 

--- a/pcmdi_metrics/variability_mode/variability_modes_driver.py
+++ b/pcmdi_metrics/variability_mode/variability_modes_driver.py
@@ -133,8 +133,13 @@ obs_var = param.varOBS
 
 # Path to model data as string template
 modpath = param.modpath
+print("modpath (from param):", modpath)
+
+modpath_lf = param.modpath_lf
 if LandMask:
-    modpath_lf = param.modpath_lf
+    print("modpath_lf (from param):", modpath_lf)
+else:
+    modpath_lf = None
 
 # Check given model option
 models = param.modnames
@@ -368,7 +373,7 @@ if obs_compare:
 
         # Calculate stdv of pc time series
         debug_print("calculate stdv of pc time series", debug)
-        stdv_pc_obs[season] = calcSTD(pc_obs[season])
+        stdv_pc_obs[season] = calcSTD(pc_obs[season])    
 
         # Linear regression to have extended global map; teleconnection purpose
         (
@@ -405,7 +410,7 @@ if obs_compare:
 
         # Set output file name for NetCDF and plot
         output_filename_obs = (
-            f"{mode}_{var}_EOF{eofn_obs}_{season}_obs_{osyear}-{oeyear}"
+            f"{mode}_{obs_var}_EOF{eofn_obs}_{season}_obs_{osyear}-{oeyear}"
         )
 
         if EofScaling:
@@ -491,6 +496,8 @@ for model in models:
 
     if model not in result_dict["RESULTS"]:
         result_dict["RESULTS"][model] = {}
+        
+    print("modpath:", modpath)
 
     model_path_list = glob.glob(
         fill_template(
@@ -560,7 +567,7 @@ for model in models:
                 "target_model_eofs"
             ] = eofn_mod
 
-            if LandMask:
+            if LandMask and modpath_lf is not None:
                 model_lf_path = fill_template(modpath_lf, mip=mip, exp=exp, model=model)
             else:
                 model_lf_path = None

--- a/pcmdi_metrics/variability_mode/variability_modes_driver.py
+++ b/pcmdi_metrics/variability_mode/variability_modes_driver.py
@@ -373,7 +373,7 @@ if obs_compare:
 
         # Calculate stdv of pc time series
         debug_print("calculate stdv of pc time series", debug)
-        stdv_pc_obs[season] = calcSTD(pc_obs[season])    
+        stdv_pc_obs[season] = calcSTD(pc_obs[season])
 
         # Linear regression to have extended global map; teleconnection purpose
         (
@@ -496,7 +496,7 @@ for model in models:
 
     if model not in result_dict["RESULTS"]:
         result_dict["RESULTS"][model] = {}
-        
+
     print("modpath:", modpath)
 
     model_path_list = glob.glob(


### PR DESCRIPTION
This PR is to make the code more flexible to run it for other datasets than CMIP. In particular for COBE2. @kristinchang3 reported an issue with CODE2, which was resulted from non-standard variable name in COBE2 when it was treated like a model data. (`sst` in COBE2 rather than `ts`). The variable name `ts` was used as a part of decision to apply landmask. The change in this PR allows 'sst' in addition. Further generalization might be needed in the future. 