### PR TITLE
re-org eof_classification api location when importing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ Analysis
 .. autosummary::
     :toctree: generated/
 
-    variability_mode.eof_classification.eof_classification
+    variability_mode.eof_classification
 
 
 Custom calendars

--- a/pcmdi_metrics/variability_mode/__init__.py
+++ b/pcmdi_metrics/variability_mode/__init__.py
@@ -1,0 +1,1 @@
+from .eof_classification.eof_classification import eof_classification

--- a/pcmdi_metrics/variability_mode/eof_classification/__init__.py
+++ b/pcmdi_metrics/variability_mode/eof_classification/__init__.py
@@ -1,1 +1,0 @@
-from .eof_classification import eof_classification

--- a/pcmdi_metrics/variability_mode/eof_classification/eof_classification.ipynb
+++ b/pcmdi_metrics/variability_mode/eof_classification/eof_classification.ipynb
@@ -127,7 +127,7 @@
      "text": [
       "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
       "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100 3378k  100 3378k    0     0  2015k      0  0:00:01  0:00:01 --:--:-- 2016k\n",
+      "100 3378k  100 3378k    0     0  1926k      0  0:00:01  0:00:01 --:--:-- 1926k\n",
       "data/\n",
       "data/example_eofs/\n",
       "data/kmeans_centers_20CR-V2_CMIP6.json\n",
@@ -164,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pcmdi_metrics.variability_mode.eof_classification import eof_classification"
+    "from pcmdi_metrics.variability_mode import eof_classification"
    ]
   },
   {


### PR DESCRIPTION
This PR is to simplify the function importing to as like
```python
from pcmdi_metrics.variability_mode import eof_classification
```
which previously was like 
```python
from pcmdi_metrics.variability_mode.eof_classification import eof_classification
```
