### PR TITLE
Bug fix on the MOV linear regression

### DIFF
--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -870,21 +870,13 @@ def multiportraitplot(
             if highlight is True:
                 # find the metric color
                 if txt in met_o1 or txt + "_1" in met_o1 or txt + "_2" in met_o1:
-                    # cc = "yellowgreen" ; alpha=1.0
-                    cc = "#66c2a5"
-                    alpha = 0.45  # teal / sea-green (102, 194, 165)
+                    cc = "yellowgreen"
                 elif txt in met_o2 or txt + "_1" in met_o2 or txt + "_2" in met_o2:
-                    # cc = "plum"; alpha=1.0
-                    cc = "#8da0cb"
-                    alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
+                    cc = "plum"
                 elif txt in met_o3 or txt + "_1" in met_o3 or txt + "_2" in met_o3:
-                    # cc = "gold"; alpha=1.0
-                    cc = "#fc8d62"
-                    alpha = 0.45  # soft orange / coral  (252, 141, 98)
+                    cc = "gold"
                 else:
-                    # cc = "turquoise"; alpha=1.0
-                    cc = "#e78ac3"
-                    alpha = 0.45  # pink / orchid (231, 138, 195)
+                    cc = "turquoise"
                 # write highlighted metric name
                 ax.text(
                     ll + 0.5,
@@ -895,9 +887,8 @@ def multiportraitplot(
                     va="top",
                     rotation=45,
                     color="k",
-                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=alpha),
+                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=1),
                 )
-
             else:
                 # write metric name in black
                 ax.text(
@@ -933,7 +924,7 @@ def multiportraitplot(
                 ax.add_line(line)
             # draw horizontal colored lines to indicate metric types
             nn = 0
-            lic, lix, lia = list(), list(), list()
+            lic, lix = list(), list()
             for uu, tt in enumerate(tmp1):
                 tmp2 = [
                     txt
@@ -942,23 +933,14 @@ def multiportraitplot(
                 ]
                 if len(tmp2) > 0:
                     if uu == 0:
-                        # cc = "yellowgreen"; alpha=1.0
-                        cc = "#66c2a5"
-                        alpha = 0.45  # teal / sea-green (102, 194, 165)
+                        cc = "yellowgreen"
                     elif uu == 1:
-                        # cc = "plum"; alpha=1.0
-                        cc = "#8da0cb"
-                        alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
+                        cc = "plum"
                     elif uu == 2:
-                        # cc = "gold"; alpha=1.0
-                        cc = "#fc8d62"
-                        alpha = 0.45  # soft orange / coral  (252, 141, 98)
+                        cc = "gold"
                     else:
-                        # cc = "turquoise"; alpha=1.0
-                        cc = "#e78ac3"
-                        alpha = 0.45  # pink / orchid (231, 138, 195)
+                        cc = "turquoise"
                     lic += [cc, cc]
-                    lia += [alpha, alpha]
                     if nn > 0:
                         lix += [[nn + 0.2, nn + len(tmp2)], [nn + 0.2, nn + len(tmp2)]]
                     else:
@@ -968,29 +950,17 @@ def multiportraitplot(
                 del tmp2
             liy = [[len(tab[0]), len(tab[0])], [0, 0]] * int(float(len(lix)) / 2)
             lis = ["-"] * len(lix)
-            for mm, (lc, ls, lx, ly, la) in enumerate(zip(lic, lis, lix, liy, lia)):
+            for mm, (lc, ls, lx, ly) in enumerate(zip(lic, lis, lix, liy)):
                 if mm < 2:
                     line = Line2D(
-                        [lx[0] + 0.05, lx[1]],
-                        ly,
-                        c=lc,
-                        lw=10,
-                        ls=ls,
-                        alpha=la,
-                        zorder=10,
+                        [lx[0] + 0.05, lx[1]], ly, c=lc, lw=10, ls=ls, zorder=10
                     )
                 elif mm > len(lis) - 3:
                     line = Line2D(
-                        [lx[0], lx[1] - 0.05],
-                        ly,
-                        c=lc,
-                        lw=10,
-                        ls=ls,
-                        alpha=la,
-                        zorder=10,
+                        [lx[0], lx[1] - 0.05], ly, c=lc, lw=10, ls=ls, zorder=10
                     )
                 else:
-                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10)
+                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, zorder=10)
                 line.set_clip_on(False)
                 ax.add_line(line)
         # y axis

--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -870,17 +870,21 @@ def multiportraitplot(
             if highlight is True:
                 # find the metric color
                 if txt in met_o1 or txt + "_1" in met_o1 or txt + "_2" in met_o1:
-                    #cc = "yellowgreen" ; alpha=1.0
-                    cc = "#66c2a5"; alpha=0.45  #teal / sea-green (102, 194, 165)
+                    # cc = "yellowgreen" ; alpha=1.0
+                    cc = "#66c2a5"
+                    alpha = 0.45  # teal / sea-green (102, 194, 165)
                 elif txt in met_o2 or txt + "_1" in met_o2 or txt + "_2" in met_o2:
-                    #cc = "plum"; alpha=1.0
-                    cc = "#8da0cb"; alpha=0.45  #muted blue / lavender-blue (141, 160, 203) 
+                    # cc = "plum"; alpha=1.0
+                    cc = "#8da0cb"
+                    alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
                 elif txt in met_o3 or txt + "_1" in met_o3 or txt + "_2" in met_o3:
-                    #cc = "gold"; alpha=1.0
-                    cc = "#fc8d62"; alpha=0.45 #soft orange / coral  (252, 141, 98)
+                    # cc = "gold"; alpha=1.0
+                    cc = "#fc8d62"
+                    alpha = 0.45  # soft orange / coral  (252, 141, 98)
                 else:
-                    #cc = "turquoise"; alpha=1.0 
-                    cc = "#e78ac3"; alpha=0.45 # pink / orchid (231, 138, 195) 
+                    # cc = "turquoise"; alpha=1.0
+                    cc = "#e78ac3"
+                    alpha = 0.45  # pink / orchid (231, 138, 195)
                 # write highlighted metric name
                 ax.text(
                     ll + 0.5,
@@ -938,17 +942,21 @@ def multiportraitplot(
                 ]
                 if len(tmp2) > 0:
                     if uu == 0:
-                        #cc = "yellowgreen"; alpha=1.0
-                        cc = "#66c2a5"; alpha=0.45  #teal / sea-green (102, 194, 165)
+                        # cc = "yellowgreen"; alpha=1.0
+                        cc = "#66c2a5"
+                        alpha = 0.45  # teal / sea-green (102, 194, 165)
                     elif uu == 1:
-                        #cc = "plum"; alpha=1.0
-                        cc = "#8da0cb"; alpha=0.45  #muted blue / lavender-blue (141, 160, 203)
+                        # cc = "plum"; alpha=1.0
+                        cc = "#8da0cb"
+                        alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
                     elif uu == 2:
-                        #cc = "gold"; alpha=1.0
-                        cc = "#fc8d62"; alpha=0.45 #soft orange / coral  (252, 141, 98)
+                        # cc = "gold"; alpha=1.0
+                        cc = "#fc8d62"
+                        alpha = 0.45  # soft orange / coral  (252, 141, 98)
                     else:
-                        #cc = "turquoise"; alpha=1.0
-                        cc = "#e78ac3"; alpha=0.45 # pink / orchid (231, 138, 195) 
+                        # cc = "turquoise"; alpha=1.0
+                        cc = "#e78ac3"
+                        alpha = 0.45  # pink / orchid (231, 138, 195)
                     lic += [cc, cc]
                     lia += [alpha, alpha]
                     if nn > 0:
@@ -963,11 +971,23 @@ def multiportraitplot(
             for mm, (lc, ls, lx, ly, la) in enumerate(zip(lic, lis, lix, liy, lia)):
                 if mm < 2:
                     line = Line2D(
-                        [lx[0] + 0.05, lx[1]], ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10
+                        [lx[0] + 0.05, lx[1]],
+                        ly,
+                        c=lc,
+                        lw=10,
+                        ls=ls,
+                        alpha=la,
+                        zorder=10,
                     )
                 elif mm > len(lis) - 3:
                     line = Line2D(
-                        [lx[0], lx[1] - 0.05], ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10
+                        [lx[0], lx[1] - 0.05],
+                        ly,
+                        c=lc,
+                        lw=10,
+                        ls=ls,
+                        alpha=la,
+                        zorder=10,
                     )
                 else:
                     line = Line2D(lx, ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10)

--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -870,13 +870,17 @@ def multiportraitplot(
             if highlight is True:
                 # find the metric color
                 if txt in met_o1 or txt + "_1" in met_o1 or txt + "_2" in met_o1:
-                    cc = "yellowgreen"
+                    #cc = "yellowgreen" ; alpha=1.0
+                    cc = "#66c2a5"; alpha=0.45  #teal / sea-green (102, 194, 165)
                 elif txt in met_o2 or txt + "_1" in met_o2 or txt + "_2" in met_o2:
-                    cc = "plum"
+                    #cc = "plum"; alpha=1.0
+                    cc = "#8da0cb"; alpha=0.45  #muted blue / lavender-blue (141, 160, 203) 
                 elif txt in met_o3 or txt + "_1" in met_o3 or txt + "_2" in met_o3:
-                    cc = "gold"
+                    #cc = "gold"; alpha=1.0
+                    cc = "#fc8d62"; alpha=0.45 #soft orange / coral  (252, 141, 98)
                 else:
-                    cc = "turquoise"
+                    #cc = "turquoise"; alpha=1.0 
+                    cc = "#e78ac3"; alpha=0.45 # pink / orchid (231, 138, 195) 
                 # write highlighted metric name
                 ax.text(
                     ll + 0.5,
@@ -887,8 +891,9 @@ def multiportraitplot(
                     va="top",
                     rotation=45,
                     color="k",
-                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=1),
+                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=alpha),
                 )
+
             else:
                 # write metric name in black
                 ax.text(
@@ -924,7 +929,7 @@ def multiportraitplot(
                 ax.add_line(line)
             # draw horizontal colored lines to indicate metric types
             nn = 0
-            lic, lix = list(), list()
+            lic, lix, lia = list(), list(), list()
             for uu, tt in enumerate(tmp1):
                 tmp2 = [
                     txt
@@ -933,14 +938,19 @@ def multiportraitplot(
                 ]
                 if len(tmp2) > 0:
                     if uu == 0:
-                        cc = "yellowgreen"
+                        #cc = "yellowgreen"; alpha=1.0
+                        cc = "#66c2a5"; alpha=0.45  #teal / sea-green (102, 194, 165)
                     elif uu == 1:
-                        cc = "plum"
+                        #cc = "plum"; alpha=1.0
+                        cc = "#8da0cb"; alpha=0.45  #muted blue / lavender-blue (141, 160, 203)
                     elif uu == 2:
-                        cc = "gold"
+                        #cc = "gold"; alpha=1.0
+                        cc = "#fc8d62"; alpha=0.45 #soft orange / coral  (252, 141, 98)
                     else:
-                        cc = "turquoise"
+                        #cc = "turquoise"; alpha=1.0
+                        cc = "#e78ac3"; alpha=0.45 # pink / orchid (231, 138, 195) 
                     lic += [cc, cc]
+                    lia += [alpha, alpha]
                     if nn > 0:
                         lix += [[nn + 0.2, nn + len(tmp2)], [nn + 0.2, nn + len(tmp2)]]
                     else:
@@ -950,17 +960,17 @@ def multiportraitplot(
                 del tmp2
             liy = [[len(tab[0]), len(tab[0])], [0, 0]] * int(float(len(lix)) / 2)
             lis = ["-"] * len(lix)
-            for mm, (lc, ls, lx, ly) in enumerate(zip(lic, lis, lix, liy)):
+            for mm, (lc, ls, lx, ly, la) in enumerate(zip(lic, lis, lix, liy, lia)):
                 if mm < 2:
                     line = Line2D(
-                        [lx[0] + 0.05, lx[1]], ly, c=lc, lw=10, ls=ls, zorder=10
+                        [lx[0] + 0.05, lx[1]], ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10
                     )
                 elif mm > len(lis) - 3:
                     line = Line2D(
-                        [lx[0], lx[1] - 0.05], ly, c=lc, lw=10, ls=ls, zorder=10
+                        [lx[0], lx[1] - 0.05], ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10
                     )
                 else:
-                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, zorder=10)
+                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10)
                 line.set_clip_on(False)
                 ax.add_line(line)
         # y axis

--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -199,19 +199,25 @@ def arbitrary_checking(mode: str, eof_Nth: xr.DataArray) -> bool:
         ):
             reverse_sign = True
     elif mode == "SAM":
-        if eof_Nth.sel({lat_key: slice(-60, -90)}).mean().item() >= 0:
+        lat = eof_Nth[lat_key]
+        lat_slice = slice(-90, -60) if lat[0] < lat[-1] else slice(-60, -90)
+        if eof_Nth.sel({lat_key: lat_slice}).mean().item() >= 0:
             reverse_sign = True
     elif mode == "PSA1":
+        lat = eof_Nth[lat_key]
+        lat_slice = slice(-59.5, -64.5) if lat[0] > lat[-1] else slice(-64.5, -59.5)
         if (
-            eof_Nth.sel({lat_key: slice(-59.5, -64.5), lon_key: slice(207.5, 212.5)})
+            eof_Nth.sel({lat_key: lat_slice, lon_key: slice(207.5, 212.5)})
             .mean()
             .item()
             >= 0
         ):
             reverse_sign = True
     elif mode == "PSA2":
+        lat = eof_Nth[lat_key]
+        lat_slice = slice(-57.5, -62.5) if lat[0] > lat[-1] else slice(-62.5, -57.5)
         if (
-            eof_Nth.sel({lat_key: slice(-57.5, -62.5), lon_key: slice(277.5, 282.5)})
+            eof_Nth.sel({lat_key: lat_slice, lon_key: slice(277.5, 282.5)})
             .mean()
             .item()
             >= 0
@@ -321,18 +327,32 @@ def linear_regression(x: xr.DataArray, y: xr.DataArray, debug: bool = False) -> 
     lat_key = get_latitude_key(y)
     lon_key = get_longitude_key(y)
 
+    # Ensure (time, lat, lon) order before indexing by position
+    time_key = get_time_key(y)
+    y = y.transpose(time_key, lat_key, lon_key)
+
     # Convert 3d (time, lat, lon) to 2d (time, lat*lon) for polyfit applying
     im = y.shape[2]
     jm = y.shape[1]
-    y_2d = y.data.reshape(y.shape[0], jm * im)
+    # Use np.asarray to handle both numpy and Dask-backed arrays
+    y_2d = np.asarray(y).reshape(y.shape[0], jm * im)
+    x_np = np.asarray(x)
     if debug:
         print("x.shape:", x.shape)
         print("y_2d.shape:", y_2d.shape)
     # Linear regression
-    slope_1d, intercept_1d = np.polyfit(np.array(x), np.array(y_2d), 1)
+    # np.polyfit (via lstsq) fails with LinAlgError on NaN columns in newer numpy.
+    # Identify columns that are fully finite and only regress those.
+    valid_cols = np.all(np.isfinite(y_2d), axis=0)
+    slope_1d = np.full(jm * im, np.nan)
+    intercept_1d = np.full(jm * im, np.nan)
+    if valid_cols.any():
+        coeffs = np.polyfit(x_np, y_2d[:, valid_cols], 1)
+        slope_1d[valid_cols] = coeffs[0]
+        intercept_1d[valid_cols] = coeffs[1]
     # Retreive to variabile from numpy array
-    slope = np.array(slope_1d.reshape(jm, im))
-    intercept = np.array(intercept_1d.reshape(jm, im))
+    slope = slope_1d.reshape(jm, im)
+    intercept = intercept_1d.reshape(jm, im)
     # Set lat/lon coordinates
     slope = xr.DataArray(
         slope, coords={lat_key: lat, lon_key: lon}, dims=[lat_key, lon_key]
@@ -341,7 +361,7 @@ def linear_regression(x: xr.DataArray, y: xr.DataArray, debug: bool = False) -> 
         intercept, coords={lat_key: lat, lon_key: lon}, dims=[lat_key, lon_key]
     )
     # return result
-    return slope.where(slope != 1e20), intercept.where(intercept != 1e20)
+    return slope, intercept
 
 
 def gain_pseudo_pcs(
@@ -389,7 +409,7 @@ def gain_pseudo_pcs(
     pseudo_pcs = pseudo_pcs[:, eofn - 1]
     # Arbitrary sign control, attempt to make all plots have the same sign
     if reverse_sign:
-        pseudo_pcs *= -1
+        pseudo_pcs = pseudo_pcs * -1
     # return result
     return pseudo_pcs
 
@@ -454,8 +474,7 @@ def gain_pcs_fraction(
     reconstructed_field = eof_pattern * pcs
 
     # 2-2) Get variance of reconstructed field
-    # time_key_2 = get_time_key(reconstructed_field)
-    time_key_2 = get_time_key(ds_eof_pattern)
+    time_key_2 = get_time_key(pcs)
     variance_partial = reconstructed_field.var(dim=[time_key_2])
     # area average
     varname_variance_partial = "variance_partial"


### PR DESCRIPTION
### Summary

This PR improves the robustness of `linear_regression` and EOF analysis sign-checking logic.

### Changes

- `linear_regression`: fix `LinAlgError: SVD did not converge` from newer NumPy versions by filtering NaN values before calling `np.polyfit`
- `linear_regression`: return NaN slope/intercept for grid points with invalid or insufficient samples instead of crashing
- `linear_regression`: explicitly transpose inputs to `(time, lat, lon)` before positional indexing
- `linear_regression`: use `np.asarray()` instead of `.data` to better support Dask-backed arrays
- `linear_regression`: remove unused `1e20` fill-value masking
- `arbitrary_checking`: fix SAM, PSA1, and PSA2 latitude slicing so it works with both ascending and descending latitude grids
- `gain_pseudo_pcs`: avoid in-place mutation of xarray data when reversing sign
- `gain_pcs_fraction`: use `get_time_key(pcs)` instead of `get_time_key(ds_eof_pattern)` to reliably identify the time dimension from the 1D PC array

### Motivation

The current implementation can crash during linear regression when NaNs are present in masked regions, such as land/ocean points. Newer NumPy versions may raise `LinAlgError: SVD did not converge` when invalid values are passed to `np.polyfit`.

This PR makes the regression behavior more robust by skipping invalid grid points and returning NaNs where a reliable fit cannot be computed.

### Testing

- Tested the updated linear regression workflow on data with masked/NaN grid points
- Verified that EOF sign-checking works with different latitude coordinate directions

Acknowledgement: Portions of these changes were developed with assistance from Claude and GitHub Copilot.