### PR TITLE
Update ENSO summary plot color scale and improve robustness

### DIFF
--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -7,7 +7,7 @@ dependencies:
     # Base
     # ==================
     # NOTE: If versions are updated, also `additional_dependencies` list for mypy in `.pre-commit-config.yaml`
-    - python >=3.10,<3.14
+    - python >=3.10,<3.15
     - pip
     - numpy >=2.0.0,<3
     - cartopy >=0.22.0

--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -870,13 +870,21 @@ def multiportraitplot(
             if highlight is True:
                 # find the metric color
                 if txt in met_o1 or txt + "_1" in met_o1 or txt + "_2" in met_o1:
-                    cc = "yellowgreen"
+                    # cc = "yellowgreen" ; alpha=1.0
+                    cc = "#66c2a5"
+                    alpha = 0.45  # teal / sea-green (102, 194, 165)
                 elif txt in met_o2 or txt + "_1" in met_o2 or txt + "_2" in met_o2:
-                    cc = "plum"
+                    # cc = "plum"; alpha=1.0
+                    cc = "#8da0cb"
+                    alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
                 elif txt in met_o3 or txt + "_1" in met_o3 or txt + "_2" in met_o3:
-                    cc = "gold"
+                    # cc = "gold"; alpha=1.0
+                    cc = "#fc8d62"
+                    alpha = 0.45  # soft orange / coral  (252, 141, 98)
                 else:
-                    cc = "turquoise"
+                    # cc = "turquoise"; alpha=1.0
+                    cc = "#e78ac3"
+                    alpha = 0.45  # pink / orchid (231, 138, 195)
                 # write highlighted metric name
                 ax.text(
                     ll + 0.5,
@@ -887,8 +895,9 @@ def multiportraitplot(
                     va="top",
                     rotation=45,
                     color="k",
-                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=1),
+                    bbox=dict(lw=0, facecolor=cc, pad=3, alpha=alpha),
                 )
+
             else:
                 # write metric name in black
                 ax.text(
@@ -924,7 +933,7 @@ def multiportraitplot(
                 ax.add_line(line)
             # draw horizontal colored lines to indicate metric types
             nn = 0
-            lic, lix = list(), list()
+            lic, lix, lia = list(), list(), list()
             for uu, tt in enumerate(tmp1):
                 tmp2 = [
                     txt
@@ -933,14 +942,23 @@ def multiportraitplot(
                 ]
                 if len(tmp2) > 0:
                     if uu == 0:
-                        cc = "yellowgreen"
+                        # cc = "yellowgreen"; alpha=1.0
+                        cc = "#66c2a5"
+                        alpha = 0.45  # teal / sea-green (102, 194, 165)
                     elif uu == 1:
-                        cc = "plum"
+                        # cc = "plum"; alpha=1.0
+                        cc = "#8da0cb"
+                        alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
                     elif uu == 2:
-                        cc = "gold"
+                        # cc = "gold"; alpha=1.0
+                        cc = "#fc8d62"
+                        alpha = 0.45  # soft orange / coral  (252, 141, 98)
                     else:
-                        cc = "turquoise"
+                        # cc = "turquoise"; alpha=1.0
+                        cc = "#e78ac3"
+                        alpha = 0.45  # pink / orchid (231, 138, 195)
                     lic += [cc, cc]
+                    lia += [alpha, alpha]
                     if nn > 0:
                         lix += [[nn + 0.2, nn + len(tmp2)], [nn + 0.2, nn + len(tmp2)]]
                     else:
@@ -950,17 +968,29 @@ def multiportraitplot(
                 del tmp2
             liy = [[len(tab[0]), len(tab[0])], [0, 0]] * int(float(len(lix)) / 2)
             lis = ["-"] * len(lix)
-            for mm, (lc, ls, lx, ly) in enumerate(zip(lic, lis, lix, liy)):
+            for mm, (lc, ls, lx, ly, la) in enumerate(zip(lic, lis, lix, liy, lia)):
                 if mm < 2:
                     line = Line2D(
-                        [lx[0] + 0.05, lx[1]], ly, c=lc, lw=10, ls=ls, zorder=10
+                        [lx[0] + 0.05, lx[1]],
+                        ly,
+                        c=lc,
+                        lw=10,
+                        ls=ls,
+                        alpha=la,
+                        zorder=10,
                     )
                 elif mm > len(lis) - 3:
                     line = Line2D(
-                        [lx[0], lx[1] - 0.05], ly, c=lc, lw=10, ls=ls, zorder=10
+                        [lx[0], lx[1] - 0.05],
+                        ly,
+                        c=lc,
+                        lw=10,
+                        ls=ls,
+                        alpha=la,
+                        zorder=10,
                     )
                 else:
-                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, zorder=10)
+                    line = Line2D(lx, ly, c=lc, lw=10, ls=ls, alpha=la, zorder=10)
                 line.set_clip_on(False)
                 ax.add_line(line)
         # y axis

--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -27,6 +27,17 @@ from numpy.ma import zeros as NUMPYma__zeros
 # ENSO_metrics functions
 from .EnsoPlotLib import plot_param
 
+# Colors (hex) and alpha for each of the four metric-type groups used in
+# highlighted portrait-plot labels and border lines.
+# Index 0 = met_o1 (background biases), 1 = met_o2 (ENSO characteristics),
+# 2 = met_o3 (teleconnections), 3 = met_o4 (processes / feedbacks).
+_METRIC_TYPE_COLORS = [
+    ("#66c2a5", 0.45),  # teal / sea-green   (102, 194, 165)
+    ("#8da0cb", 0.45),  # muted blue / lavender-blue (141, 160, 203)
+    ("#fc8d62", 0.45),  # soft orange / coral        (252, 141,  98)
+    ("#e78ac3", 0.45),  # pink / orchid              (231, 138, 195)
+]
+
 # ---------------------------------------------------#
 # Main
 # ---------------------------------------------------#
@@ -762,7 +773,7 @@ def get_reference(metric_collection, metric):
 
 def my_colorbar(mini=-1.0, maxi=1.0, nbins=20):
     """
-    Modifies cmo.balance colobar (removes the darkest blue and red)
+    Builds a truncated RdBu_r colormap (removes the darkest blue and red ends)
 
     Inputs:
     ------
@@ -782,7 +793,6 @@ def my_colorbar(mini=-1.0, maxi=1.0, nbins=20):
         Normalize, a class which can normalize data into the [0.0, 1.0] interval.
     """
     levels = MaxNLocator(nbins=nbins).tick_values(mini, maxi)
-    # cmap = plt.get_cmap("cmo.balance")
     cmap = plt.get_cmap("RdBu_r")
     newcmp1 = cmap(NUMPYlinspace(0.15, 0.85, 256))
     newcmp2 = cmap(NUMPYlinspace(0.0, 1.0, 256))
@@ -868,23 +878,17 @@ def multiportraitplot(
         ax.set_xticklabels([] * len(ticks))
         for ll, txt in enumerate(x_names[kk]):
             if highlight is True:
-                # find the metric color
-                if txt in met_o1 or txt + "_1" in met_o1 or txt + "_2" in met_o1:
-                    # cc = "yellowgreen" ; alpha=1.0
-                    cc = "#66c2a5"
-                    alpha = 0.45  # teal / sea-green (102, 194, 165)
-                elif txt in met_o2 or txt + "_1" in met_o2 or txt + "_2" in met_o2:
-                    # cc = "plum"; alpha=1.0
-                    cc = "#8da0cb"
-                    alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
-                elif txt in met_o3 or txt + "_1" in met_o3 or txt + "_2" in met_o3:
-                    # cc = "gold"; alpha=1.0
-                    cc = "#fc8d62"
-                    alpha = 0.45  # soft orange / coral  (252, 141, 98)
-                else:
-                    # cc = "turquoise"; alpha=1.0
-                    cc = "#e78ac3"
-                    alpha = 0.45  # pink / orchid (231, 138, 195)
+                # find the metric color from the module-level constant
+                _met_type_lists = [met_o1, met_o2, met_o3, met_o4]
+                met_type_idx = next(
+                    (
+                        i
+                        for i, tt in enumerate(_met_type_lists)
+                        if txt in tt or txt + "_1" in tt or txt + "_2" in tt
+                    ),
+                    3,  # default: met_o4 color
+                )
+                cc, alpha = _METRIC_TYPE_COLORS[met_type_idx]
                 # write highlighted metric name
                 ax.text(
                     ll + 0.5,
@@ -941,22 +945,7 @@ def multiportraitplot(
                     if txt in tt or txt + "_1" in tt or txt + "_2" in tt
                 ]
                 if len(tmp2) > 0:
-                    if uu == 0:
-                        # cc = "yellowgreen"; alpha=1.0
-                        cc = "#66c2a5"
-                        alpha = 0.45  # teal / sea-green (102, 194, 165)
-                    elif uu == 1:
-                        # cc = "plum"; alpha=1.0
-                        cc = "#8da0cb"
-                        alpha = 0.45  # muted blue / lavender-blue (141, 160, 203)
-                    elif uu == 2:
-                        # cc = "gold"; alpha=1.0
-                        cc = "#fc8d62"
-                        alpha = 0.45  # soft orange / coral  (252, 141, 98)
-                    else:
-                        # cc = "turquoise"; alpha=1.0
-                        cc = "#e78ac3"
-                        alpha = 0.45  # pink / orchid (231, 138, 195)
+                    cc, alpha = _METRIC_TYPE_COLORS[uu]
                     lic += [cc, cc]
                     lia += [alpha, alpha]
                     if nn > 0:
@@ -964,7 +953,7 @@ def multiportraitplot(
                     else:
                         lix += [[nn, nn + len(tmp2)], [nn, nn + len(tmp2)]]
                     nn += len(tmp2)
-                    del cc
+                    del cc, alpha
                 del tmp2
             liy = [[len(tab[0]), len(tab[0])], [0, 0]] * int(float(len(lix)) / 2)
             lis = ["-"] * len(lix)

--- a/pcmdi_metrics/graphics/parallel_coordinate_plot/parallel_coordinate_plot_lib.py
+++ b/pcmdi_metrics/graphics/parallel_coordinate_plot/parallel_coordinate_plot_lib.py
@@ -324,15 +324,15 @@ def parallel_coordinate_plot(
                     hue="group",
                     split=True,
                     linewidth=0.1,
-                    density_norm="count",  # replaces scale="count"
+                    density_norm="width",  # replaces scale="count"
                     common_norm=True,  # replaces scale_hue=False
                     palette={
                         group1_name: violin_colors[0],
                         group2_name: violin_colors[1],
                     },
-                    cut=0,
-                    bw_adjust=2.0,
-                    gridsize=300,
+                    cut=0.5,  # slightly extend KDE beyond sampled min/max to avoid abrupt clipping
+                    bw_adjust=2.0,  # smooth KDE, useful when one group has few samples
+                    gridsize=300,  # smoother violin boundary
                 )
 
     # Line or marker

--- a/pcmdi_metrics/graphics/parallel_coordinate_plot/parallel_coordinate_plot_lib.py
+++ b/pcmdi_metrics/graphics/parallel_coordinate_plot/parallel_coordinate_plot_lib.py
@@ -324,13 +324,15 @@ def parallel_coordinate_plot(
                     hue="group",
                     split=True,
                     linewidth=0.1,
-                    scale="count",
-                    scale_hue=False,
+                    density_norm="count",  # replaces scale="count"
+                    common_norm=True,  # replaces scale_hue=False
                     palette={
                         group1_name: violin_colors[0],
                         group2_name: violin_colors[1],
                     },
                     cut=0,
+                    bw_adjust=2.0,
+                    gridsize=300,
                 )
 
     # Line or marker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ backend-path = ["_custom_build"]
 name = "pcmdi_metrics"
 description = "model metrics tools"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 license = { file = "LICENSE" }
 authors = [{ name = "PCMDI" }]
 classifiers = [


### PR DESCRIPTION
**Summary**

This PR updates the color scheme used in the ENSO summary portrait plot and refactors the color-selection logic to improve maintainability, consistency, and visual clarity.

**Changes**

- plot.py: 

1. `Replaced hard-coded named colors (yellowgreen, plum, gold, turquoise) with a centralized _METRIC_TYPE_COLORS constant using ColorBrewer qualitative colors (#66c2a5, #8da0cb, #fc8d62, #e78ac3) and a consistent alpha of 0.45. This provides a more cohesive and accessible palette for distinguishing the four metric groups: background biases, ENSO characteristics, teleconnections, and processes/feedbacks. `
2. `Simplified the color-selection logic by replacing the cascading if/elif chain with a concise next(..., default) expression, improving readability and making it easier to extend or reorder metric groups.`
3. Propagated the alpha value consistently to both text bounding-box labels and horizontal Line2D indicators.
4. Replaced the cmo.balance colormap with RdBu_r, removing the dependency on cmo.balance.

- dev.yml / pyproject.toml

- Updated the supported Python version range to include Python 3.14, aligning with the latest e3sm_unified environment.