### PR TITLE
Fix provenance when `conda` is not available

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -2,7 +2,6 @@
 name: pcmdi_metrics_ci
 channels:
     - conda-forge
-    - defaults
 dependencies:
     # ==================
     # Base

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -2,7 +2,6 @@
 name: pcmdi_metrics_dev
 channels:
     - conda-forge
-    - defaults
 dependencies:
     # ==================
     # Base

--- a/pcmdi_metrics/io/base.py
+++ b/pcmdi_metrics/io/base.py
@@ -48,7 +48,33 @@ def _determine_conda():
     return conda_exe
 
 
+def _determine_pixi():
+    """
+    Attempt to determine the path to the pixi executable, or return None if not available.
+    """
+    import shutil
+
+    override_pixi_exe = os.environ.get("PCMDI_PIXI_EXE")
+    if override_pixi_exe:
+        return override_pixi_exe
+
+    # PIXI_EXE is set by pixi when it activates an environment
+    pixi_exe = os.environ.get("PIXI_EXE")
+    if pixi_exe and os.path.exists(pixi_exe):
+        return pixi_exe
+
+    return shutil.which("pixi")
+
+
+def _is_pixi_env():
+    """Return True if running inside a pixi-managed environment."""
+    return bool(
+        os.environ.get("PIXI_ENVIRONMENT_NAME") or os.environ.get("PIXI_PROJECT_ROOT")
+    )
+
+
 CONDA = _determine_conda()
+PIXI = _determine_pixi()
 
 # ----------
 # Standalone functions
@@ -141,19 +167,7 @@ def generateProvenance(extra_pairs={}, history=True):
     prov["osAccess"] = bool(os.access("/", os.W_OK) * os.access("/", os.R_OK))
     prov["commandLine"] = " ".join(sys.argv)
     prov["date"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    prov["conda"] = OrderedDict()
-    pairs = {
-        "Platform": "platform ",
-        "Version": "conda version ",
-        "IsPrivate": "conda is private ",
-        "envVersion": "conda-env version ",
-        "buildVersion": "conda-build version ",
-        "PythonVersion": "python version ",
-        "RootEnvironment": "root environment ",
-        "DefaultEnvironment": "default environment ",
-    }
-    populate_prov(prov["conda"], CONDA + " info", pairs, sep=":", index=-1)
-    pairs = {
+    package_pairs = {
         "cdp": "cdp ",
         "cdat_info": "cdat_info ",
         "esmf": "esmf ",
@@ -165,13 +179,50 @@ def generateProvenance(extra_pairs={}, history=True):
         "xcdat": "xcdat ",
         "xarray": "xarray ",
     }
-    # Actual environement used
-    p = Popen(shlex.split(CONDA + " env export"), stdout=PIPE, stderr=PIPE)
-    o, e = p.communicate()
-    prov["conda"]["yaml"] = o.decode("utf-8")
     prov["packages"] = OrderedDict()
-    populate_prov(prov["packages"], CONDA + " list", pairs, fill_missing=None)
-    populate_prov(prov["packages"], CONDA + " list", extra_pairs, fill_missing=None)
+    if _is_pixi_env() and PIXI:
+        prov["pixi"] = OrderedDict()
+        try:
+            p = Popen(shlex.split(PIXI + " info"), stdout=PIPE, stderr=PIPE)
+            o, _ = p.communicate()
+            prov["pixi"]["info"] = o.decode("utf-8")
+        except Exception:
+            pass
+        try:
+            p = Popen(shlex.split(PIXI + " list"), stdout=PIPE, stderr=PIPE)
+            o, _ = p.communicate()
+            prov["pixi"]["list"] = o.decode("utf-8")
+        except Exception:
+            pass
+        populate_prov(
+            prov["packages"], PIXI + " list", package_pairs, fill_missing=None
+        )
+        populate_prov(prov["packages"], PIXI + " list", extra_pairs, fill_missing=None)
+    else:
+        prov["conda"] = OrderedDict()
+        conda_info_pairs = {
+            "Platform": "platform ",
+            "Version": "conda version ",
+            "IsPrivate": "conda is private ",
+            "envVersion": "conda-env version ",
+            "buildVersion": "conda-build version ",
+            "PythonVersion": "python version ",
+            "RootEnvironment": "root environment ",
+            "DefaultEnvironment": "default environment ",
+        }
+        populate_prov(
+            prov["conda"], CONDA + " info", conda_info_pairs, sep=":", index=-1
+        )
+        try:
+            p = Popen(shlex.split(CONDA + " env export"), stdout=PIPE, stderr=PIPE)
+            o, _ = p.communicate()
+            prov["conda"]["yaml"] = o.decode("utf-8")
+        except Exception:
+            pass
+        populate_prov(
+            prov["packages"], CONDA + " list", package_pairs, fill_missing=None
+        )
+        populate_prov(prov["packages"], CONDA + " list", extra_pairs, fill_missing=None)
     # Trying to capture glxinfo
     pairs = {
         "vendor": "OpenGL vendor string",

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,90 @@
+import os
+from unittest import mock
+
+from pcmdi_metrics.io.base import generateProvenance
+
+
+def _mock_popen(stdout=b"", stderr=b""):
+    proc = mock.MagicMock()
+    proc.communicate.return_value = (stdout, stderr)
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Branch selection: conda vs pixi
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("pcmdi_metrics.io.base.Popen")
+def test_provenance_conda_branch(mock_popen):
+    """Uses conda provenance when PIXI env vars are absent."""
+    mock_popen.return_value = _mock_popen()
+    env = {"PIXI_ENVIRONMENT_NAME": "", "PIXI_PROJECT_ROOT": ""}
+    with mock.patch.dict(os.environ, env):
+        prov = generateProvenance(history=False)
+
+    assert "conda" in prov
+    assert "pixi" not in prov
+    assert "packages" in prov
+
+
+@mock.patch("pcmdi_metrics.io.base.Popen")
+def test_provenance_pixi_branch(mock_popen):
+    """Uses pixi provenance when PIXI_ENVIRONMENT_NAME is set."""
+    mock_popen.return_value = _mock_popen()
+    env = {"PIXI_ENVIRONMENT_NAME": "default", "PIXI_PROJECT_ROOT": "/fake/project"}
+    with mock.patch.dict(os.environ, env):
+        with mock.patch("pcmdi_metrics.io.base.PIXI", "/fake/pixi"):
+            prov = generateProvenance(history=False)
+
+    assert "pixi" in prov
+    assert "info" in prov["pixi"]
+    assert "list" in prov["pixi"]
+    assert "conda" not in prov
+    assert "packages" in prov
+
+
+# ---------------------------------------------------------------------------
+# Robustness: no executable available
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("pcmdi_metrics.io.base.Popen", side_effect=FileNotFoundError)
+def test_provenance_no_conda_executable(mock_popen):
+    """Does not raise when the conda executable is missing."""
+    env = {"PIXI_ENVIRONMENT_NAME": "", "PIXI_PROJECT_ROOT": ""}
+    with mock.patch.dict(os.environ, env):
+        prov = generateProvenance(history=False)
+
+    assert "conda" in prov  # key created even when subprocess fails
+
+
+@mock.patch("pcmdi_metrics.io.base.Popen", side_effect=FileNotFoundError)
+def test_provenance_no_pixi_executable(mock_popen):
+    """Does not raise when the pixi executable is missing."""
+    env = {"PIXI_ENVIRONMENT_NAME": "default", "PIXI_PROJECT_ROOT": "/fake/project"}
+    with mock.patch.dict(os.environ, env):
+        with mock.patch("pcmdi_metrics.io.base.PIXI", "/nonexistent/pixi"):
+            prov = generateProvenance(history=False)
+
+    assert "pixi" in prov  # key created even when subprocess fails
+
+
+# ---------------------------------------------------------------------------
+# Core provenance keys are always present
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("pcmdi_metrics.io.base.Popen")
+def test_provenance_core_keys(mock_popen):
+    """Platform, userId, date, and packages keys are always populated."""
+    mock_popen.return_value = _mock_popen()
+    env = {"PIXI_ENVIRONMENT_NAME": "", "PIXI_PROJECT_ROOT": ""}
+    with mock.patch.dict(os.environ, env):
+        prov = generateProvenance(history=False)
+
+    for key in ("platform", "userId", "osAccess", "commandLine", "date", "packages"):
+        assert key in prov
+
+    assert "OS" in prov["platform"]
+    assert "Name" in prov["platform"]


### PR DESCRIPTION
E3SM-Unified now uses [pixi](https://pixi.prefix.dev/latest/) not conda for its environments.  This causes crashes in calls to pcmdi_metrics when trying to use `conda` as part of writing provenance. This PR adds support for `pixi` during provenance.

I have added a unit test to make sure provenance succeeds and shown that it does with a pixi environment I created that is identical to the `ci.yml` environment.

Finally, I removed the `defaults` channel from `ci.yml` and `dev.yml` as packages from that channel [require a license](https://www.anaconda.com/legal).