### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
+++ b/pcmdi_metrics/enso/lib/summary_plot_lib/plot.py
@@ -1016,7 +1016,7 @@ def multiportraitplot(
         aspect=40,
     )
     cbar.ax.set_yticklabels(
-        ["-2 $\sigma$", "-1", "MMV", "1", "2 $\sigma$"], fontdict=fontdict  # noqa
+        [r"-2 $\sigma$", "-1", "MMV", "1", r"2 $\sigma$"], fontdict=fontdict  # noqa
     )
     dict_arrow = dict(facecolor="k", width=8, headwidth=40, headlength=40, shrink=0.0)
     dict_txt = dict(fontsize=40, rotation="vertical", ha="center", weight="bold")

--- a/tests/test_drcdm.py
+++ b/tests/test_drcdm.py
@@ -7,11 +7,12 @@ from pcmdi_metrics.drcdm.lib import compute_metrics
 
 def create_random_precip(years, max_val=None, min_val=None):
     # Returns array of precip along with sftlf
-    times = xr.cftime_range(
+    times = xr.date_range(
         start="{0}-01-01".format(years[0]),
         end="{0}-12-31".format(years[1]),
         freq="D",
         calendar="noleap",
+        use_cftime=True,
         name="time",
     )
     latd = 2
@@ -36,6 +37,7 @@ def create_random_precip(years, max_val=None, min_val=None):
 
     fake_ds["time"].encoding["calendar"] = "noleap"
     fake_ds["time"].encoding["units"] = "days since 0000-01-01"
+    fake_ds["lat"].attrs["units"] = "degrees_north"
     fake_ds = fake_ds.bounds.add_missing_bounds()
 
     if max_val is not None:
@@ -55,6 +57,7 @@ def create_random_precip(years, max_val=None, min_val=None):
             )
         }
     )
+    sftlf["lat"].attrs["units"] = "degrees_north"
     sftlf = sftlf.bounds.add_missing_bounds(["X", "Y"])
 
     return fake_ds, sftlf
@@ -66,11 +69,12 @@ def create_seasonal_precip(season):
     mos = sd[season]
 
     years = [1980, 1981]
-    times = xr.cftime_range(
+    times = xr.date_range(
         start="{0}-01-01".format(years[0]),
         end="{0}-12-31".format(years[1]),
         freq="D",
         calendar="noleap",
+        use_cftime=True,
         name="time",
     )
     latd = 2
@@ -99,6 +103,7 @@ def create_seasonal_precip(season):
     )
     fake_ds["time"].encoding["calendar"] = "noleap"
     fake_ds["time"].encoding["units"] = "days since 0000-01-01"
+    fake_ds["lat"].attrs["units"] = "degrees_north"
     fake_ds = fake_ds.bounds.add_missing_bounds()
 
     sftlf_arr = np.ones((latd, lond))
@@ -113,6 +118,7 @@ def create_seasonal_precip(season):
             )
         }
     )
+    sftlf["lat"].attrs["units"] = "degrees_north"
     sftlf = sftlf.bounds.add_missing_bounds(["X", "Y"])
 
     return fake_ds, sftlf

--- a/tests/test_extremes.py
+++ b/tests/test_extremes.py
@@ -6,11 +6,12 @@ from pcmdi_metrics.extremes.lib import compute_metrics
 
 def create_random_precip(years, max_val=None, min_val=None):
     # Returns array of precip along with covariate and sftlf
-    times = xr.cftime_range(
+    times = xr.date_range(
         start="{0}-01-01".format(years[0]),
         end="{0}-12-31".format(years[1]),
         freq="D",
         calendar="noleap",
+        use_cftime=True,
         name="time",
     )
     latd = 2
@@ -48,6 +49,7 @@ def create_random_precip(years, max_val=None, min_val=None):
 
     fake_ds["time"].encoding["calendar"] = "noleap"
     fake_ds["time"].encoding["units"] = "days since 0000-01-01"
+    fake_ds["lat"].attrs["units"] = "degrees_north"
     fake_ds = fake_ds.bounds.add_missing_bounds()
 
     if max_val is not None:
@@ -67,6 +69,7 @@ def create_random_precip(years, max_val=None, min_val=None):
             )
         }
     )
+    sftlf["lat"].attrs["units"] = "degrees_north"
     sftlf = sftlf.bounds.add_missing_bounds(["X", "Y"])
 
     return fake_ds, fake_cov, sftlf
@@ -78,11 +81,12 @@ def create_seasonal_precip(season):
     mos = sd[season]
 
     years = [1980, 1981]
-    times = xr.cftime_range(
+    times = xr.date_range(
         start="{0}-01-01".format(years[0]),
         end="{0}-12-31".format(years[1]),
         freq="D",
         calendar="noleap",
+        use_cftime=True,
         name="time",
     )
     latd = 2
@@ -111,6 +115,7 @@ def create_seasonal_precip(season):
     )
     fake_ds["time"].encoding["calendar"] = "noleap"
     fake_ds["time"].encoding["units"] = "days since 0000-01-01"
+    fake_ds["lat"].attrs["units"] = "degrees_north"
     fake_ds = fake_ds.bounds.add_missing_bounds()
 
     sftlf_arr = np.ones((latd, lond)) * 100
@@ -125,6 +130,7 @@ def create_seasonal_precip(season):
             )
         }
     )
+    sftlf["lat"].attrs["units"] = "degrees_north"
     sftlf = sftlf.bounds.add_missing_bounds(["X", "Y"])
 
     return fake_ds, sftlf

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -13,8 +13,8 @@ from pcmdi_metrics.utils import (
 @pytest.fixture
 def create_dataset():
     def _create_dataset(start_date, periods, freq, calendar="gregorian"):
-        dates = xr.cftime_range(
-            start_date, periods=periods, freq=freq, calendar=calendar
+        dates = xr.date_range(
+            start_date, periods=periods, freq=freq, calendar=calendar, use_cftime=True
         )
         return xr.Dataset({"time": dates})
 
@@ -50,13 +50,13 @@ def test_check_daily_time_axis_missing_time_key(create_dataset):
 # Test check_monthly_time_axis
 @pytest.mark.parametrize("calendar", ["gregorian", "noleap", "360_day"])
 def test_check_monthly_time_axis_correct(create_dataset, calendar):
-    ds = create_dataset("2000-01-01", 24, "M", calendar=calendar)
+    ds = create_dataset("2000-01-01", 24, "ME", calendar=calendar)
     assert check_monthly_time_axis(ds) is None
 
 
 def test_check_monthly_time_axis_incorrect(create_dataset):
     # Test with incorrect monthly sequence
-    ds = create_dataset("2000-01-01", 24, "2M")
+    ds = create_dataset("2000-01-01", 24, "2ME")
     with pytest.raises(ValueError, match="DATA ERROR: time is not correct!"):
         check_monthly_time_axis(ds)
 
@@ -68,7 +68,7 @@ def test_check_monthly_time_axis_non_datetime():
 
 
 def test_check_monthly_time_axis_missing_time_key(create_dataset):
-    ds = create_dataset("2000-01-01", 24, "M")
+    ds = create_dataset("2000-01-01", 24, "ME")
     with pytest.raises(KeyError):
         check_monthly_time_axis(ds, time_key="non_existent_key")
 

--- a/tests/test_sea_ice.py
+++ b/tests/test_sea_ice.py
@@ -6,11 +6,12 @@ from pcmdi_metrics.sea_ice.lib import sea_ice_lib as lib
 
 def create_fake_sea_ice_ds():
     years = [1980, 1999]
-    times = xr.cftime_range(
+    times = xr.date_range(
         start="{0}-01-01".format(years[0]),
         end="{0}-12-31".format(years[1]),
         freq="ME",
         calendar="noleap",
+        use_cftime=True,
         name="time",
     )
     latd = 2


### PR DESCRIPTION
This PR fixes several warnings that came up in unit tests.

There were issues with latex symbols being interpreted as escape characters, which are fixed by using r-strings.

There were two future warnings:
* `FutureWarning: cftime_range() is deprecated, please use xarray.date_range(..., use_cftime=True) instead.`
* `FutureWarning: 'M' is deprecated and will be removed in a future version. Please use 'ME' instead of 'M'`

Finally, there was this warning:
```
[WARNING]: bounds.py(create_bounds:983) >> The 'lat' coordinate variable is missing a 'units' attribute. Assuming 'units' is 'degrees_north'.
```

They are all fixed in this PR. 