### PR TITLE
Update plot_wavenumber_frequency_power.py

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -11,7 +11,7 @@ dependencies:
     - pip >=23.1.2
     - numpy >=2.0.0,<3
     - cartopy >=0.22.0
-    - matplotlib >=3.7.1
+    - matplotlib >=3.9.0
     - eofs >=2.0.0
     - seaborn >=0.12.2
     - enso_metrics >=2.0.0

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -11,7 +11,7 @@ dependencies:
     - pip
     - numpy >=2.0.0,<3
     - cartopy >=0.22.0
-    - matplotlib >=3.7.1
+    - matplotlib >=3.9.0
     - eofs >=2.0.0
     - seaborn >=0.12.2
     - enso_metrics >=2.0.0

--- a/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
+++ b/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
@@ -1,8 +1,6 @@
-import copy
 import os
 import warnings
 
-import matplotlib.cm
 import matplotlib.pyplot as plt
 import xarray as xr
 from matplotlib.patches import Rectangle

--- a/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
+++ b/pcmdi_metrics/mjo/lib/plot_wavenumber_frequency_power.py
@@ -53,7 +53,7 @@ def plot_power(
     # plot
     plt.switch_backend("agg")  # backend plotting
     plt.figure(figsize=(8, 4))
-    cm = copy.copy(matplotlib.cm.get_cmap("jet"))
+    cm = plt.colormaps["jet"]
     cs = plt.contourf(
         x,
         y,


### PR DESCRIPTION
Hi @lee1043 when running MJO Demo 5 Notebook to test PR #1389 on the Main branch, I discovered that matplotlib v3.9+ has removed the function get_cmap(), resulting in the error described here Issue #1390 . 


I created the conda environment using dev.yml, which installed matplotlib v3.11.0 . I suggest changing the function to match the latest versions of matplotlib. As our yaml files only specify matplotlib >= 3.7.1, I suggest upgrading the dependency to >= 3.9 to avoid any conflict with this change. 

Let me know what you think and I can submit a PR to update those yaml files! 