### PR TITLE
Clean up doc

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -27,4 +27,4 @@ A suite of demo scripts and interactive Jupyter notebooks are provided with `thi
    metrics_precip-distribution
    metrics_subdaily-precipitation
    metrics_sea_ice
-   Cloud Feedbacks <https://github.com/PCMDI/pcmdi_metrics/blob/main/pcmdi_metrics/cloud_feedback/README.md>
+   metrics_cloud-feedback

--- a/docs/metrics_cloud-feedback.rst
+++ b/docs/metrics_cloud-feedback.rst
@@ -1,0 +1,100 @@
+.. title:: PMP Cloud Feedback
+
+
+*****************
+Cloud Feedbacks
+*****************
+
+Overview
+========
+
+The cloud feedback metrics implemented in PMP are originally from `assessed-cloud-fbks <https://github.com/mzelinka/assessed-cloud-fbks>`_ |DOI|,
+developed by `@mzelinka <https://mzelinka.github.io/>`_ at LLNL. This code performs the analysis of Zelinka et al. (2022).
+It computes GCM cloud feedback components and compares them to the expert-assessed values from Sherwood et al. (2020).
+
+.. |DOI| image:: https://zenodo.org/badge/353136800.svg
+   :target: https://zenodo.org/badge/latestdoi/353136800
+
+
+Instructions
+============
+
+To use the cloud feedback metrics, follow these steps:
+
+
+1. Install PMP
+##############
+
+Install PMP via conda following the `installation instructions <http://pcmdi.github.io/pcmdi_metrics/install.html>`_. For example: ::
+
+    conda create -n [YOUR_CONDA_ENVIRONMENT] -c conda-forge pcmdi_metrics
+
+
+2. Activate PMP installed conda environment
+###########################################
+
+Activate your environment (if PMP installed env is different from your current one): ::
+
+    conda activate [YOUR_CONDA_ENVIRONMENT]
+
+
+3. Clone PMP repo to your local
+################################
+
+Clone PMP repo to your local for pre-calculated data: ::
+
+    git clone https://github.com/PCMDI/pcmdi_metrics
+
+Once completed, go to ``pcmdi_metrics/pcmdi_metrics/cloud_feedback`` directory: ::
+
+    cd [YOUR LOCAL CLONED PMP REPOSITORY]
+    cd pcmdi_metrics/pcmdi_metrics/cloud_feedback
+
+
+4. Edit parameter files
+#######################
+
+In `param/my_param.py <https://github.com/PCMDI/pcmdi_metrics/blob/main/pcmdi_metrics/cloud_feedback/param/my_param.py>`_,
+update the "User Input" section so it points to your model's amip and amip-p4K files: ::
+
+    # User Input:
+    # ================================================================================================
+    model = "GFDL-CM4"
+    variant = "r1i1p1f1"
+
+    input_files_json = "./param/input_files.json"
+
+    # Flag to compute ECS
+    # True: compute ECS using abrupt-4xCO2 run
+    # False: do not compute, instead rely on ECS value present in the json file (if it exists)
+    # get_ecs = True
+    get_ecs = False
+
+    # Output directory path (directory will be generated if it does not exist yet.)
+    xml_path = "./xmls/"
+    figure_path = "./figures/"
+    output_path = "./output"
+    output_json_filename = "_".join(["cloud_feedback", model, variant]) + ".json"
+    # ================================================================================================
+
+You will need to update `param/input_files.json <https://github.com/PCMDI/pcmdi_metrics/blob/main/pcmdi_metrics/cloud_feedback/param/input_files.json>`_
+file as well to provide data path for your input files.
+
+
+5. Run the code and inspect the generated output files
+#######################################################
+
+Run calculation: ::
+
+    python cloud_feedback_driver.py -p param/my_param.py
+
+Once code is completed, check ``output`` directory (``output_path`` from the above parameter file) for JSON
+and ``figures`` directory (``figure_path`` from the above parameter file) for figures and text tables.
+
+
+References
+==========
+
+* Zelinka et al. (2022): `Evaluating climate models' cloud feedbacks against expert judgement <https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021JD035198>`_, *J. Geophys. Res.*, 127, e2021JD035198, doi:10.1029/2021JD035198.
+
+* Sherwood et al. (2020): `A combined assessment of Earth's climate sensitivity <https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019RG000678>`_, *Rev. Geophys.*, 58, e2019RG000678, doi:10.1029/2019RG000678.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,22 +1,27 @@
 .. title:: PMP Overview
 
-
 .. _overview:
 
 ***********
 Overview
 ***********
 
-The PMP provides a diverse suite of analysis utilities each of which produce summary statistics that gauge the consistency between climate model simulations and available observations.  
-The primary application of the PMP is to evaluate simulations from the `Coupled Model Intercomparison Project (CMIP) <https://www.wcrp-climate.org/wgcm-cmip>`_.  
-It can also be used to provide objective performance summaries during the model development process as well as selected research purposes.  
-The notes below provide a brief summary of some of the key aspects of the PMP design.  
+The PMP provides a diverse suite of analysis utilities, each producing summary statistics that gauge the consistency between climate model simulations and available observations.
+
+The primary application of the PMP is to evaluate simulations from the `Coupled Model Intercomparison Project (CMIP) <https://www.wcrp-climate.org/wgcm-cmip>`_. It can also be used to provide objective performance summaries during the model development process as well as for selected research purposes.
+
+The sections below provide a brief summary of key aspects of the PMP design.
+
+Introduction Video
+------------------
 
 .. raw:: html
 
     <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 80%; height: auto; margin-left: auto; margin-right: auto">
         <iframe src="https://www.youtube.com/embed/STfCq5Biqf0" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div>
+
+|
 
 References
 ----------
@@ -25,41 +30,17 @@ Lee, J., P. J. Gleckler, M.-S. Ahn, A. Ordonez, P. Ullrich, K. R. Sperber, K. E.
 Gleckler et al. (2016), A more powerful reality test for climate models, Eos, 97, `doi:10.1029/2016EO051663 <https://eos.org/science-updates/a-more-powerful-reality-test-for-climate-models>`_.
 
 
-Software framework and dependencies
------------------------------------
+Software Framework and Dependencies
+------------------------------------
 
-Most of the PMP is based on `Python 3 <https://www.python.org/>`_ and built upon the `Xarray <https://docs.xarray.dev/en/stable/>`_ and the Xarray Climate Data Analysis Tools (`xCDAT`_). 
+The PMP is based on `Python 3 <https://www.python.org/>`_ and built upon `Xarray <https://docs.xarray.dev/en/stable/>`_ and the Xarray Climate Data Analysis Tools (`xCDAT`_). 
 
-Input/Output format
--------------------
+Input/Output Format
+--------------------
 
-The PMP is designed to most readily handle model output that adheres to the `Climate-Forecast (CF) data conventions <https://cfconventions.org/>`_.  
-More specifically, because the PMP is used to routinely analyze simulations contributed to CMIP it leverages `the data conventions developed in support of CMIP <https://pcmdi.llnl.gov/CMIP6/Guide/dataUsers.html>`_.  
-Many modeling groups have a workflow that conforms to CMIP or is very similar to it, making it possible to adapt the PMP to assist in the model development process. 
+The PMP is designed to handle model output that adheres to the `Climate-Forecast (CF) data conventions <https://cfconventions.org/>`_. More specifically, because the PMP is used to routinely analyze simulations contributed to CMIP, it leverages `the data conventions developed in support of CMIP <https://pcmdi.llnl.gov/CMIP6/Guide/dataUsers.html>`_. Many modeling groups have workflows that conform to CMIP or are very similar to it, making it possible to adapt the PMP to assist in the model development process.
 
 The PMP statistics are output in `JSON format <https://www.json.org/json-en.html>`_, and the underlying diagnostics from which they were derived are typically saved in `netCDF format <https://www.unidata.ucar.edu/software/netcdf>`_.
 
-
-Basic Operation
----------------
-
-The summary statistics available with the PMP can be run independently or as a collective (the later to be available via the next PMP version).  Here is a glimpse of how the mean climate statistics are executed from the unix command prompt: ::
-
-    $ mean_climate_driver.py -p e3sm_parameterfile.py 
-
-Because there are often multiple parameters to set before executing a PMP code, routine operation often involves setting these options in an "input parameter" python file such as the filename immediately following the "-p" flag above.  The PMP input parameter files are similiar to a "namelist" text file used in other climate analysis packages but having the input parameters set in a python file enables us to leverage the power of python. For example, the contents of an input parameter file might look something like this: ::
-
-    $ more input_parameters.py
-    $ test_data_set = ['ACCESS-1-0','CESM2']
-    $ period = '1981-2005'
-
-which includes both a string variable (period) and a python list (test_data_set). Other python objects can be included in input parameter files, notably python dictionaries.  Additional functionality is shown in another example command: ::
-
-   $ mean_climate_driver.py -p e3sm_parameterfile.py --variable pr 
-
-Here, the "---variable" option is used to specify "pr" (precipitation) with other options included in the file after the "-p" flag.  
-
-
-The python standard `argparse libary <https://docs.python.org/3/library/argparse.html>`_  is implicitly used in all cases, enabling the inclusion of user-friendly interface options.  As in the above example, this allows users to set input parameters on the command line **or** in an input file.  However, there are circumstances where users of the PMP may want to use a combination of both (an input parameter file and command line setting) for the same execution. This useful combination is possible with the standard argeparse library however with limited functionality.  We make use of the Community Diagnostics Package (`CDP <https://github.com/CDAT/cdp>`_) to enable prioritization between the two input possibilities.  The CDP enables us to use command line options in combination with input parameter files, with the command line inputs overriding options set in the parameter files.  This provides convenience in setting up and maintaining large jobs. Examples of the combined use of parameter files and command line inputs are included in the PMP demos.
 
 .. _xCDAT: https://xcdat.readthedocs.io/en/stable/


### PR DESCRIPTION
* Updated overview page -- removed 'basic operation' section as API style will be more promoted. 
* Update cloud feedback doc: Instead of link to README.md from the github repository, a .rst file created based on the README.md for consistency across docs for metrics.