### PR TITLE
Lower SAM/NAM diagnostic memory footprint by 50x

### DIFF
--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -78,6 +78,9 @@ def eof_analysis_get_variance_mode(
     grid_area = calculate_grid_area(ds)
     area_weights = calculate_area_weights(grid_area)
     da = ds[data_var]
+    # Force dask-backed data to numpy to avoid O(n^2) memory usage for dask's SVD
+    if da.chunks is not None:
+        da = da.load()
     solver = Eof(da, weights=area_weights)
     debug_print("Lib-EOF: eof", debug)
 

--- a/pcmdi_metrics/variability_mode/lib/eof_analysis.py
+++ b/pcmdi_metrics/variability_mode/lib/eof_analysis.py
@@ -78,7 +78,7 @@ def eof_analysis_get_variance_mode(
     grid_area = calculate_grid_area(ds)
     area_weights = calculate_area_weights(grid_area)
     da = ds[data_var]
-    # Force dask-backed data to numpy to avoid O(n^2) memory usage for dask's SVD
+    # Force to use numpy instead of dask due to O(n^2) memory requirements
     if da.chunks is not None:
         da = da.load()
     solver = Eof(da, weights=area_weights)


### PR DESCRIPTION
For the Climate-REF SAM/NAM diagnostics I was seeing a huge jump in wall time and memory usage for higher resolution runs. Up to 150 GB and 2 1/2 hours for a half-degree grid when the mean case took 8mins.
For the CMIP7 runs for UKCM2a-0-HH, it used more than 700GB of RAM.

The issue was that the Dask chunks were extremely inefficient when calculating the EOF, causing O(n^2) memory usage and lower run times. This fix just materialises the data so it uses plain numpy. The materialised data is only about 85MB at that point in time.

Runs went from 154GB, 165 min -> 2.9GB, 4 min