### PR TITLE
prevents roundoff to 1.00 in mean_climate figures

### DIFF
--- a/pcmdi_metrics/mean_climate/lib/plot_clim_maps.py
+++ b/pcmdi_metrics/mean_climate/lib/plot_clim_maps.py
@@ -255,7 +255,12 @@ def plot_climatology_diff(
                 corr = cor_xy(
                     ds_test_season[data_var_test], ds_ref_season[data_var_ref]
                 )
-                info_stats += f"\nCORR {corr:.2f}"
+                corr_str = f"{corr:.2f}"
+
+                if corr_str in ("1.00", "-1.00"):
+                    corr_str = f"{corr:.3f}"
+
+                info_stats += f"\nCORR {corr_str}"
             except Exception as e:
                 print(f"Error computing correlation: {e}")
                 corr = None


### PR DESCRIPTION
Prevents round off to "1.00" or "-1.00" correlation in mean_climate difference plots. Confirmed that the image size does not cut off the metric diagnostics. In an edge case of comparing two identical datasets, "1.000" will appear. 

Before: 
<img width="765" height="1320" alt="image" src="https://github.com/user-attachments/assets/ea6071db-03f9-4258-a6ce-905788f588ac" />


After:
<img width="765" height="1320" alt="image" src="https://github.com/user-attachments/assets/6e5a6248-4a14-4c48-9b96-c18e26230380" />

